### PR TITLE
Fuzzy match implementation

### DIFF
--- a/src/Lifti.Core/ExceptionMessages.Designer.cs
+++ b/src/Lifti.Core/ExceptionMessages.Designer.cs
@@ -133,6 +133,15 @@ namespace Lifti {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Expected a fuzzy match token - got {0}.
+        /// </summary>
+        internal static string ExpectedFuzzyMatchToken {
+            get {
+                return ResourceManager.GetString("ExpectedFuzzyMatchToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A text fragment must follow a multi-character wildcard in a wildcard expression.
         /// </summary>
         internal static string ExpectedTextQueryFragmentAfterMultiCharacterWildcard {

--- a/src/Lifti.Core/ExceptionMessages.resx
+++ b/src/Lifti.Core/ExceptionMessages.resx
@@ -141,6 +141,9 @@
   <data name="ExpectedAtLeastOneQueryPartParsed" xml:space="preserve">
     <value>Expected at least one query part to be parsed</value>
   </data>
+  <data name="ExpectedFuzzyMatchToken" xml:space="preserve">
+    <value>Expected a fuzzy match token - got {0}</value>
+  </data>
   <data name="ExpectedTextQueryFragmentAfterMultiCharacterWildcard" xml:space="preserve">
     <value>A text fragment must follow a multi-character wildcard in a wildcard expression</value>
   </data>

--- a/src/Lifti.Core/Querying/IIndexNavigator.cs
+++ b/src/Lifti.Core/Querying/IIndexNavigator.cs
@@ -23,12 +23,18 @@ namespace Lifti.Querying
         /// <summary>
         /// Gets all the items that are indexed under from where the navigator is located.
         /// </summary>
-        IntermediateQueryResult GetExactAndChildMatches();
+        /// <param name="weighting">
+        /// The weighting to apply to the matched tokens. This can be used to adjust the resulting score for the match.
+        /// </param>
+        IntermediateQueryResult GetExactAndChildMatches(double weighting = 1D);
 
         /// <summary>
         /// Gets all the items that are indexed exactly at the point of the navigators current location.
         /// </summary>
-        IntermediateQueryResult GetExactMatches();
+        /// <param name="weighting">
+        /// The weighting to apply to the matched tokens. This can be used to adjust the resulting score for the match.
+        /// </param>
+        IntermediateQueryResult GetExactMatches(double weighting = 1D);
 
         /// <summary>
         /// Processes a single character, moving the navigator along the index.

--- a/src/Lifti.Core/Querying/IScorer.cs
+++ b/src/Lifti.Core/Querying/IScorer.cs
@@ -13,10 +13,13 @@ namespace Lifti.Querying
         /// <param name="tokens">
         /// The <see cref="QueryTokenMatch"/> instances to score.
         /// </param>
+        /// <param name="weighting">
+        /// The weighting multiplier to apply to the score.
+        /// </param>
         /// <returns>
         /// The <see cref="ScoredToken"/> represenations of the input <paramref name="tokens"/>. There will be a 1:1
         /// mapping of input -> output and the order will be preserved.
         /// </returns>
-        IReadOnlyList<ScoredToken> Score(IReadOnlyList<QueryTokenMatch> tokens);
+        IReadOnlyList<ScoredToken> Score(IReadOnlyList<QueryTokenMatch> tokens, double weighting);
     }
 }

--- a/src/Lifti.Core/Querying/QueryParser.cs
+++ b/src/Lifti.Core/Querying/QueryParser.cs
@@ -123,7 +123,7 @@ namespace Lifti.Querying
 
             var tokenText = queryToken.TokenText.AsSpan();
             var result = tokenizer.Process(tokenText)
-                 .Select(token => new FuzzyMatchQueryPart(token.Value, queryToken.Tolerance))
+                 .Select(token => new FuzzyMatchQueryPart(token.Value))
                  .FirstOrDefault();
 
             if (result == null)

--- a/src/Lifti.Core/Querying/QueryParts/AdjacentWordsQueryOperator.cs
+++ b/src/Lifti.Core/Querying/QueryParts/AdjacentWordsQueryOperator.cs
@@ -20,7 +20,7 @@ namespace Lifti.Querying.QueryParts
         }
 
         /// <summary>
-        /// Gets the <see cref="IWordQueryPart"/>s that must appear in sequence.
+        /// Gets the <see cref="IQueryPart"/>s that must appear in sequence.
         /// </summary>
         public IReadOnlyList<IQueryPart> Words { get; }
 

--- a/src/Lifti.Core/Querying/QueryParts/DoubleBufferedList.cs
+++ b/src/Lifti.Core/Querying/QueryParts/DoubleBufferedList.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace Lifti.Querying.QueryParts
+{
+    internal class DoubleBufferedList<T> : IEnumerable<T>
+    {
+        private List<T> current = new List<T>();
+        private List<T> swap = new List<T>();
+
+        public DoubleBufferedList()
+        {
+        }
+
+        public DoubleBufferedList(params T[] initialData)
+        {
+            this.current.AddRange(initialData);
+        }
+
+        public void Add(T item)
+        {
+            this.swap.Add(item);
+        }
+
+        public int Count => this.current.Count;
+
+        public void Swap()
+        {
+            var tempStack = this.current;
+            tempStack.Clear();
+            this.current = this.swap;
+            this.swap = tempStack;
+        }
+
+        public IEnumerator<T> GetEnumerator()
+        {
+            return this.current.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+    }
+}

--- a/src/Lifti.Core/Querying/QueryParts/DoubleBufferedList.cs
+++ b/src/Lifti.Core/Querying/QueryParts/DoubleBufferedList.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Lifti.Querying.QueryParts
@@ -20,6 +21,11 @@ namespace Lifti.Querying.QueryParts
         public void Add(T item)
         {
             this.swap.Add(item);
+        }
+
+        public void AddRange(IEnumerable<T> items)
+        {
+            this.swap.AddRange(items);
         }
 
         public int Count => this.current.Count;

--- a/src/Lifti.Core/Querying/QueryParts/ExactWordQueryPart.cs
+++ b/src/Lifti.Core/Querying/QueryParts/ExactWordQueryPart.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
 
 namespace Lifti.Querying.QueryParts
 {

--- a/src/Lifti.Core/Querying/QueryParts/ExactWordQueryPart.cs
+++ b/src/Lifti.Core/Querying/QueryParts/ExactWordQueryPart.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Lifti.Querying.QueryParts
 {

--- a/src/Lifti.Core/Querying/QueryParts/FuzzyMatchQueryPart.cs
+++ b/src/Lifti.Core/Querying/QueryParts/FuzzyMatchQueryPart.cs
@@ -78,6 +78,9 @@ namespace Lifti.Querying.QueryParts
             /// <summary>
             /// Creates a new <see cref="FuzzyMatchState"/> instance.
             /// </summary>
+#if DEBUG && TRACK_MATCH_STATE_TEXT
+            /// <param name="matchText">The debug text used to illustrate the alterations that were made to the original search term to reach this point.</param>
+#endif
             /// <param name="bookmark">The <see cref="IIndexNavigatorBookmark"/> for the state of the index that this instance is for.</param>
             /// <param name="totalEditCount">The current number number of edits this required to reach this point in the match.</param>
             /// <param name="levenshteinDistance">The Levelshtein distance accumulated so far. This will differ from <paramref name="totalEditCount"/> 
@@ -85,9 +88,6 @@ namespace Lifti.Querying.QueryParts
             /// <param name="sequentialEdits">The number of sequential edits that have accumulated so far to reach this point. When
             /// an exact match is processed, this will be reset to zero.</param>
             /// <param name="wordIndex">The current index in the search term.</param>
-#if DEBUG && TRACK_MATCH_STATE_TEXT
-            /// <param name="matchText">The debug text used to illustrate the alterations that were made to the original search term to reach this point.</param>
-#endif
             /// <param name="lastSubstitution">The character substitution that was made at the last character, or null if the last operation was 
             /// not a substitution. This is used to identify the case where letters have been transposed.</param>
             public FuzzyMatchState(
@@ -107,9 +107,9 @@ namespace Lifti.Querying.QueryParts
                 this.LevenshteinDistance = levenshteinDistance;
                 this.SequentialEdits = sequentialEdits;
                 this.WordIndex = wordIndex;
+                this.LastSubstitution = lastSubstitution;
 #if DEBUG && TRACK_MATCH_STATE_TEXT
                 this.MatchText = matchText;
-                this.LastSubstitution = lastSubstitution;
 #endif
             }
 

--- a/src/Lifti.Core/Querying/QueryParts/FuzzyMatchQueryPart.cs
+++ b/src/Lifti.Core/Querying/QueryParts/FuzzyMatchQueryPart.cs
@@ -259,7 +259,7 @@ namespace Lifti.Querying.QueryParts
                                 // Calculate the weighting as ((L1 + L2)-E)/(L1 + L2) where
                                 // L1 = Search term length
                                 // L2 = Matched term length
-                                // E = Number of edits
+                                // E = The Levenshtein distance between the search term and match
                                 // So for a word with no edits, we have a weighting of (L-0)/L = 1
                                 // All other weightings will be less than 1, with more edits drawing the weighting towards zero
                                 var lengthTotal = searchTermLength + characterCount;

--- a/src/Lifti.Core/Querying/QueryParts/FuzzyMatchQueryPart.cs
+++ b/src/Lifti.Core/Querying/QueryParts/FuzzyMatchQueryPart.cs
@@ -10,7 +10,7 @@ namespace Lifti.Querying.QueryParts
     /// <summary>
     /// An <see cref="IQueryPart"/> that matches items that contain an fuzzy match for the given text.
     /// </summary>
-    public class FuzzyWordQueryPart : WordQueryPart
+    public class FuzzyMatchQueryPart : WordQueryPart
     {
         private readonly int maxEditDistance;
 
@@ -120,9 +120,9 @@ namespace Lifti.Querying.QueryParts
         }
 
         /// <summary>
-        /// Constructs a new instance of <see cref="ExactWordQueryPart"/>.
+        /// Constructs a new instance of <see cref="FuzzyMatchQueryPart"/>.
         /// </summary>
-        public FuzzyWordQueryPart(string word, int maxEditDistance)
+        public FuzzyMatchQueryPart(string word, int maxEditDistance)
             : base(word)
         {
             this.maxEditDistance = maxEditDistance;

--- a/src/Lifti.Core/Querying/QueryParts/FuzzyWordQueryPart.cs
+++ b/src/Lifti.Core/Querying/QueryParts/FuzzyWordQueryPart.cs
@@ -1,0 +1,223 @@
+﻿#define TRACK_MATCH_STATE_TEXT
+// Enabling TRACK_MATCH_STATE_TEXT in DEBUG builds will allow you inspect the state of a fuzzy match
+// as it is being processed using the MatchText property. This is not available in release builds for performance.
+
+using System;
+
+namespace Lifti.Querying.QueryParts
+{
+    /// <summary>
+    /// An <see cref="IQueryPart"/> that matches items that contain an fuzzy match for the given text.
+    /// </summary>
+    public class FuzzyWordQueryPart : WordQueryPart
+    {
+        private readonly int maxEditDistance;
+
+        private enum EditKind
+        {
+            Substitution,
+            Deletion
+        }
+
+        private struct FuzzyMatchState
+        {
+#if DEBUG && TRACK_MATCH_STATE_TEXT
+            public FuzzyMatchState(
+                IIndexNavigatorBookmark bookmark,
+                int editCount,
+                int wordIndex,
+                string matchText) : this()
+            {
+                this.Bookmark = bookmark;
+                this.EditDistance = editCount;
+                this.WordIndex = wordIndex;
+                this.MatchText = matchText;
+            }
+#else
+            public FuzzyMatchState(IIndexNavigatorBookmark bookmark, int editDistance, int wordIndex) : this()
+            {
+                this.Bookmark = bookmark;
+                this.EditDistance = editDistance;
+                this.WordIndex = wordIndex;
+            }
+#endif
+
+            public FuzzyMatchState(IIndexNavigatorBookmark bookmark)
+                : this(
+                      bookmark,
+                      0,
+                      0
+#if DEBUG && TRACK_MATCH_STATE_TEXT
+                      , string.Empty
+#endif
+                      )
+            {
+            }
+
+            public IIndexNavigatorBookmark Bookmark { get; }
+
+            public int EditDistance { get; }
+
+            /// <summary>
+            /// The index that this state is currently matching in the target word.
+            /// </summary>
+            public int WordIndex { get; }
+
+#if DEBUG && TRACK_MATCH_STATE_TEXT
+            public string MatchText { get; }
+#endif
+        }
+
+        /// <summary>
+        /// Constructs a new instance of <see cref="ExactWordQueryPart"/>.
+        /// </summary>
+        public FuzzyWordQueryPart(string word, int maxEditDistance)
+            : base(word)
+        {
+            this.maxEditDistance = maxEditDistance;
+        }
+
+        /// <inheritdoc/>
+        public override IntermediateQueryResult Evaluate(Func<IIndexNavigator> navigatorCreator, IQueryContext queryContext)
+        {
+            if (navigatorCreator == null)
+            {
+                throw new ArgumentNullException(nameof(navigatorCreator));
+            }
+
+            using var navigator = navigatorCreator();
+            var results = IntermediateQueryResult.Empty;
+            var stateStore = new DoubleBufferedList<FuzzyMatchState>(new FuzzyMatchState(navigator.CreateBookmark()));
+
+            var characterCount = 0;
+            do
+            {
+                foreach (var state in stateStore)
+                {
+                    var wordIndex = state.WordIndex;
+                    var bookmark = state.Bookmark;
+                    bookmark.Apply();
+
+                    if (state.WordIndex == this.Word.Length)
+                    {
+                        // Don't allow matches that have consisted entirely of edits
+                        if (characterCount > state.EditDistance)
+                        {
+                            // We're out of search characters for this state.
+                            if (navigator.HasExactMatches)
+                            {
+                                results = results.Union(navigator.GetExactMatches());
+                            }
+                            else
+                            {
+                                // Assume there could be missing characters at the end
+                                AddBookmarksForAllTraversableCharacters(navigator, stateStore, state, EditKind.Deletion);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        var currentCharacter = this.Word[wordIndex];
+                        if (navigator.Process(currentCharacter))
+                        {
+                            // The character matched successfully, so potentially no edits incurred, just move to the next character
+                            stateStore.Add(
+                                new FuzzyMatchState(
+                                    navigator.CreateBookmark(),
+                                    state.EditDistance,
+                                    wordIndex + 1
+#if DEBUG && TRACK_MATCH_STATE_TEXT
+                                , state.MatchText + currentCharacter
+#endif
+                                ));
+                        }
+                        else
+                        {
+                            // First skip this character (assume extra character inserted), but don't move the navigator on
+                            if (state.EditDistance < this.maxEditDistance)
+                            {
+                                stateStore.Add(
+                                    new FuzzyMatchState(
+                                        bookmark,
+                                        state.EditDistance + 1,
+                                        wordIndex + 1
+#if DEBUG && TRACK_MATCH_STATE_TEXT
+                                        , state.MatchText + $"(+{currentCharacter})"
+#endif
+                            ));
+                            }
+
+                            // Also try skipping this character (assume omission) by just moving on in the navigator
+                            AddBookmarksForAllTraversableCharacters(navigator, stateStore, state, EditKind.Deletion);
+                        }
+
+                        // Always assume this could be a substituted character
+                        AddBookmarksForAllTraversableCharacters(navigator, stateStore, state, EditKind.Substitution, except: currentCharacter);
+                    }
+                }
+
+                stateStore.Swap();
+
+                characterCount++;
+            }
+            while (stateStore.Count > 0);
+
+            // TODO adjust score based on edit count
+            return results;
+        }
+
+        private void AddBookmarksForAllTraversableCharacters(
+            IIndexNavigator navigator,
+            DoubleBufferedList<FuzzyMatchState> stateStore,
+            FuzzyMatchState currentState,
+            EditKind editKind,
+            char? except = null)
+        {
+            var bookmark = currentState.Bookmark;
+            var nextEditDistance = currentState.EditDistance + 1;
+            var nextIndex = editKind switch
+            {
+                EditKind.Deletion => currentState.WordIndex,
+                _ => currentState.WordIndex + 1
+            };
+
+            if (nextEditDistance > this.maxEditDistance)
+            {
+                // Stop processing - we've reached the maximum number of allowed edits
+                return;
+            }
+
+            bookmark.Apply();
+            foreach (char c in navigator.EnumerateNextCharacters())
+            {
+                if (except == c)
+                {
+                    continue;
+                }
+
+                bookmark.Apply();
+                navigator.Process(c);
+                stateStore.Add(
+                    new FuzzyMatchState(
+                        navigator.CreateBookmark(),
+                        nextEditDistance,
+                        nextIndex
+#if DEBUG && TRACK_MATCH_STATE_TEXT
+                        , editKind switch
+                        {
+                            EditKind.Substitution => currentState.MatchText + $"(-{this.Word[currentState.WordIndex]}{c}?)",
+                            EditKind.Deletion => currentState.MatchText + $"(-{c})",
+                            _ => throw new InvalidOperationException("Unsupported edit kind!")
+                        }
+#endif
+                        ));
+            }
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Word;
+        }
+    }
+}

--- a/src/Lifti.Core/Querying/QueryParts/FuzzyWordQueryPart.cs
+++ b/src/Lifti.Core/Querying/QueryParts/FuzzyWordQueryPart.cs
@@ -118,33 +118,30 @@ namespace Lifti.Querying.QueryParts
                     else
                     {
                         var currentCharacter = this.Word[wordIndex];
-                        if (navigator.Process(currentCharacter))
+                        void AddToStateStore(IIndexNavigatorBookmark bookmark, int editDistance)
                         {
-                            // The character matched successfully, so potentially no edits incurred, just move to the next character
                             stateStore.Add(
                                 new FuzzyMatchState(
-                                    navigator.CreateBookmark(),
-                                    state.EditDistance,
+                                    bookmark,
+                                    editDistance,
                                     wordIndex + 1
 #if DEBUG && TRACK_MATCH_STATE_TEXT
                                 , state.MatchText + currentCharacter
 #endif
                                 ));
                         }
+
+                        if (navigator.Process(currentCharacter))
+                        {
+                            // The character matched successfully, so potentially no edits incurred, just move to the next character
+                            AddToStateStore(navigator.CreateBookmark(), state.EditDistance);
+                        }
                         else
                         {
                             // First skip this character (assume extra character inserted), but don't move the navigator on
                             if (state.EditDistance < this.maxEditDistance)
                             {
-                                stateStore.Add(
-                                    new FuzzyMatchState(
-                                        bookmark,
-                                        state.EditDistance + 1,
-                                        wordIndex + 1
-#if DEBUG && TRACK_MATCH_STATE_TEXT
-                                        , state.MatchText + $"(+{currentCharacter})"
-#endif
-                            ));
+                                AddToStateStore(bookmark, state.EditDistance + 1);
                             }
 
                             // Also try skipping this character (assume omission) by just moving on in the navigator

--- a/src/Lifti.Core/Querying/QueryToken.cs
+++ b/src/Lifti.Core/Querying/QueryToken.cs
@@ -42,6 +42,14 @@ namespace Lifti.Querying
         public static QueryToken ForText(string text) => new QueryToken(text, QueryTokenType.Text, 0);
 
         /// <summary>
+        /// Creates a new <see cref="QueryToken"/> instance representing a textual part of the query with fuzzy matching.
+        /// </summary>
+        /// <param name="text">
+        /// The text to be matched by the query.
+        /// </param>
+        public static QueryToken ForFuzzyText(string text) => new QueryToken(text, QueryTokenType.FuzzyMatch, 3);
+
+        /// <summary>
         /// Creates a new <see cref="QueryToken"/> instance representing a field filter.
         /// </summary>
         /// <param name="fieldName">

--- a/src/Lifti.Core/Querying/QueryTokenType.cs
+++ b/src/Lifti.Core/Querying/QueryTokenType.cs
@@ -58,7 +58,12 @@
         /// <summary>
         /// The token is a field filter - the captured token is the field that results should be restricted to.
         /// </summary>
-        FieldFilter
+        FieldFilter,
+
+        /// <summary>
+        /// The token text is a fuzzy match.
+        /// </summary>
+        FuzzyMatch
     }
 
 }

--- a/test/Lifti.Tests/FullTextIndexBuilderTests.cs
+++ b/test/Lifti.Tests/FullTextIndexBuilderTests.cs
@@ -75,8 +75,8 @@ namespace Lifti.Tests
         {
             var score = 999999999D;
             var indexScorer = new Mock<IScorer>();
-            indexScorer.Setup(s => s.Score(It.IsAny<IReadOnlyList<QueryTokenMatch>>()))
-                .Returns((IReadOnlyList<QueryTokenMatch> t) => t.Select(m => new ScoredToken(m.ItemId, m.FieldMatches.Select(fm => new ScoredFieldMatch(score, fm)).ToList())).ToList());
+            indexScorer.Setup(s => s.Score(It.IsAny<IReadOnlyList<QueryTokenMatch>>(), It.IsAny<double>()))
+                .Returns((IReadOnlyList<QueryTokenMatch> t, double weight) => t.Select(m => new ScoredToken(m.ItemId, m.FieldMatches.Select(fm => new ScoredFieldMatch(score, fm)).ToList())).ToList());
 
             var scorer = new Mock<IIndexScorerFactory>();
             scorer.Setup(s => s.CreateIndexScorer(It.IsAny<IIndexSnapshot>())).Returns(indexScorer.Object);

--- a/test/Lifti.Tests/Querying/FakeIndexNavigator.cs
+++ b/test/Lifti.Tests/Querying/FakeIndexNavigator.cs
@@ -56,12 +56,12 @@ namespace Lifti.Tests.Querying
             return new FakeIndexNavigator(true, matches);
         }
 
-        public IntermediateQueryResult GetExactAndChildMatches()
+        public IntermediateQueryResult GetExactAndChildMatches(double weighting = 1D)
         {
             return this.ExpectedExactAndChildMatches;
         }
 
-        public IntermediateQueryResult GetExactMatches()
+        public IntermediateQueryResult GetExactMatches(double weighting = 1D)
         {
             return this.ExpectedExactMatches;
         }

--- a/test/Lifti.Tests/Querying/OkapiBm25ScorerTests.cs
+++ b/test/Lifti.Tests/Querying/OkapiBm25ScorerTests.cs
@@ -1,0 +1,64 @@
+﻿using FluentAssertions;
+using Lifti.Querying;
+using Moq;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Lifti.Tests.Querying
+{
+    public class OkapiBm25ScorerTests : QueryTestBase
+    {
+        private const double expectedScore1 = 2.536599214033677D;
+        private const double expectedScore2 = 2.3792189708272073D;
+
+        private readonly OkapiBm25Scorer sut;
+        private readonly QueryTokenMatch[] tokenMatches;
+
+        public OkapiBm25ScorerTests()
+        {
+            var snapshotMock = new Mock<IItemStore>();
+            snapshotMock.SetupGet(s => s.Count).Returns(10); // 10 items in the index
+            snapshotMock.SetupGet(s => s.IndexStatistics).Returns(
+                new IndexStatistics(ImmutableDictionary<byte, long>.Empty.Add(1, 100), 100)); // 100 total tokens in 1 field
+
+            snapshotMock.Setup(s => s.GetMetadata(It.IsAny<int>())).Returns(
+                (int id) => new ItemMetadata<int>(id, id, new DocumentStatistics(1, id * 3))); // Each item will have (id * 3) tokens in it
+
+            this.sut = new OkapiBm25Scorer(1.2D, 0.75D, snapshotMock.Object);
+
+            this.tokenMatches = new[]
+{
+                new QueryTokenMatch(1, new[] { FieldMatch(1, 3, 6) }),
+                new QueryTokenMatch(3, new[] { FieldMatch(1, 8, 2, 5) })
+            };
+        }
+
+        [Fact]
+        public void VerifyScoreWithoutWeighting()
+        {
+            var results = this.sut.Score(tokenMatches, 1D);
+
+            results.Should().BeEquivalentTo(
+                new[]
+                {
+                    new ScoredToken(1, new[] { ScoredFieldMatch(expectedScore1, 1, 3, 6) }),
+                    new ScoredToken(3, new[] { ScoredFieldMatch(expectedScore2, 1, 8, 2, 5) })
+                },
+                o => o.Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.00001D)).When(i => i.RuntimeType == typeof(double)));
+        }
+
+        [Fact]
+        public void VerifyScoreWithWeighting()
+        {
+            var results = this.sut.Score(tokenMatches, 0.5D);
+
+            results.Should().BeEquivalentTo(
+                new[]
+                {
+                    new ScoredToken(1, new[] { ScoredFieldMatch(expectedScore1 / 2D, 1, 3, 6) }),
+                    new ScoredToken(3, new[] { ScoredFieldMatch(expectedScore2 / 2D, 1, 8, 2, 5) })
+                },
+                o => o.Using<double>(ctx => ctx.Subject.Should().BeApproximately(ctx.Expectation, 0.00001D)).When(i => i.RuntimeType == typeof(double)));
+        }
+    }
+}

--- a/test/Lifti.Tests/Querying/QueryParserTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParserTests.cs
@@ -34,6 +34,29 @@ namespace Lifti.Tests.Querying
         }
 
         [Fact]
+        public void ParsingTwoFuzzyWordsWithNoOperator_ShouldComposeWithAndOperator()
+        {
+            var result = this.Parse("?wordone ?wordtwo");
+            var expectedQuery = new AndQueryOperator(new FuzzyMatchQueryPart("wordone", 3), new FuzzyMatchQueryPart("wordtwo", 3));
+            VerifyResult(result, expectedQuery);
+        }
+
+        [Fact]
+        public void ParsingMixOfWordMatchesWithNoOperator_ShouldComposeWithAndOperators()
+        {
+            var result = this.Parse("?wordone wordtwo wor* ?wordthree");
+            var expectedQuery =
+                new AndQueryOperator(
+                    new AndQueryOperator(
+                        new AndQueryOperator(
+                            new FuzzyMatchQueryPart("wordone", 3), 
+                            new ExactWordQueryPart("wordtwo")),
+                        new WildcardQueryPart(WildcardQueryFragment.CreateText("wor"), WildcardQueryFragment.MultiCharacter)),
+                    new FuzzyMatchQueryPart("wordthree",3));
+            VerifyResult(result, expectedQuery);
+        }
+
+        [Fact]
         public void ParsingTwoWordsWithAndOperator_ShouldComposeWithAndOperator()
         {
             var result = this.Parse("wordone & wordtwo");

--- a/test/Lifti.Tests/Querying/QueryParts/FuzzyWordQueryPartTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/FuzzyWordQueryPartTests.cs
@@ -106,7 +106,7 @@ namespace Lifti.Tests.Querying.QueryParts
 
         private double GetScore(string search, int maxDistance)
         {
-            var part = new FuzzyWordQueryPart(search, maxDistance);
+            var part = new FuzzyMatchQueryPart(search, maxDistance);
             var results = this.fixture.Index.Search(new Query(part)).ToList();
             return results.Where(r => r.FieldMatches.Any(m => m.Locations.Any(l => l.TokenIndex == 1)) && r.Key == 0)
                 .Select(s => s.Score)
@@ -138,7 +138,7 @@ namespace Lifti.Tests.Querying.QueryParts
                     x => new TokenLocation(x.index, x.startLocation, (ushort)x.Value.Length)).ToList()))
                 .ToList();
 
-            var part = new FuzzyWordQueryPart(word, maxEditDistance);
+            var part = new FuzzyMatchQueryPart(word, maxEditDistance);
 
             var results = this.fixture.Index.Search(new Query(part)).ToList();
 

--- a/test/Lifti.Tests/Querying/QueryParts/FuzzyWordQueryPartTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/FuzzyWordQueryPartTests.cs
@@ -110,7 +110,7 @@ namespace Lifti.Tests.Querying.QueryParts
             expectedScoreOrders.Should().BeInDescendingOrder();
         }
 
-        private double GetScore(string search, short maxDistance, short maxSequentialEdits)
+        private double GetScore(string search, ushort maxDistance, ushort maxSequentialEdits)
         {
             var part = new FuzzyMatchQueryPart(search, maxDistance, maxSequentialEdits);
             var results = this.fixture.Index.Search(new Query(part)).ToList();
@@ -119,7 +119,7 @@ namespace Lifti.Tests.Querying.QueryParts
                 .Single();
         }
 
-        private void RunTest(string word, short maxEditDistance, short maxSequentialEdits, params string[] expectedWords)
+        private void RunTest(string word, ushort maxEditDistance, ushort maxSequentialEdits, params string[] expectedWords)
         {
             var expectedWordLookup = expectedWords.ToHashSet(StringComparer.OrdinalIgnoreCase);
             var expectedMatchRegex = new Regex(@"(^|\s)*((?<word>[^\s]*)($|\s))+");

--- a/test/Lifti.Tests/Querying/QueryParts/FuzzyWordQueryPartTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/FuzzyWordQueryPartTests.cs
@@ -1,0 +1,153 @@
+﻿using FluentAssertions;
+using Lifti.Querying;
+using Lifti.Querying.QueryParts;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Lifti.Tests.Querying.QueryParts
+{
+    public class FuzzyWordQueryPartTestsFixture : IAsyncLifetime
+    {
+        public string[] IndexedText { get; } = {
+            "Some sample text to match on",
+            "Sounds like a solid plan to me",
+            "Odius ogres obey Mobius"
+        };
+
+        public FullTextIndex<int> Index { get; private set; }
+
+        public Task DisposeAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task InitializeAsync()
+        {
+            this.Index = new FullTextIndexBuilder<int>()
+                .Build();
+
+            this.Index.BeginBatchChange();
+
+            for (var i = 0; i < IndexedText.Length; i++)
+            {
+                await this.Index.AddAsync(i, IndexedText[i]);
+            }
+
+            await this.Index.CommitBatchChangeAsync();
+        }
+    }
+
+    public class FuzzyWordQueryPartTests : IClassFixture<FuzzyWordQueryPartTestsFixture>
+    {
+       
+        private readonly ITestOutputHelper outputHelper;
+        private readonly FuzzyWordQueryPartTestsFixture fixture;
+
+        public FuzzyWordQueryPartTests(ITestOutputHelper outputHelper, FuzzyWordQueryPartTestsFixture fixture)
+        {
+            this.outputHelper = outputHelper;
+            this.fixture = fixture;
+        }
+
+        [Fact]
+        public void ShouldReturnExactMatch()
+        {
+            RunTest("SAMPLE", 2, "sample");
+        }
+
+        [Fact]
+        public void MaxDistanceOfOne_ShouldHandleSubstitutions()
+        {
+            RunTest("SONE", 1, "some");
+        }
+
+        [Fact]
+        public void MaxDistanceOfOne_ShouldHandleDeletions()
+        {
+            RunTest("SOE", 1, "some");
+        }
+
+        [Fact]
+        public void MaxDistanceOfOne_ShouldHandleInsertions()
+        {
+            RunTest("SOMME", 1, "some");
+        }
+
+        [Fact]
+        public void MaxDistanceOfThree_ShouldReturnAllPotentialVariations()
+        {
+            RunTest("OBAN", 3, "obey", "plan", "on");
+        }
+
+        [Fact]
+        public void ShouldNotAllowVariationsConsistingEntirelyOfEdits()
+        {
+            RunTest("OT", 2, "on");
+        }
+
+        private void RunTest(string word, int maxEditDistance, params string[] expectedWords)
+        {
+            var expectedWordLookup = expectedWords.ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var expectedMatchRegex = new Regex(@"(^|\s)*((?<word>[^\s]*)($|\s))+");
+            var expectedResultCaptures = this.fixture.IndexedText.Select(
+                (text, id) =>
+                    (
+                    id,
+                    expectedMatchRegex.Match(text).Groups["word"]
+                        .Captures
+                        .Select((x, index) => (index, startLocation: x.Index, x.Value))
+                        .Where(c => expectedWordLookup.Contains(c.Value))
+                        .ToList()
+                    ))
+                .Where(r => r.Item2.Count > 0);
+
+            // Double-check that each of the expected words has been translated to its matching positions in the test articles
+            expectedResultCaptures.SelectMany(s => s.Item2.Select(i => i.Value)).ToHashSet(StringComparer.OrdinalIgnoreCase)
+                .Should().HaveCount(expectedWords.Length, because: "Each of the expected words should be found at least once in the source articles");
+
+            var expectedResults = expectedResultCaptures.Select(
+                r => (r.id, r.Item2.Select(
+                    x => new TokenLocation(x.index, x.startLocation, (ushort)x.Value.Length)).ToList()))
+                .ToList();
+
+            var part = new FuzzyWordQueryPart(word, maxEditDistance);
+
+            var results = this.fixture.Index.Search(new Query(part)).ToList();
+
+            outputHelper.WriteLine("Expected matches:");
+            WriteMatches(expectedResults);
+
+            outputHelper.WriteLine("Actual matches:");
+            WriteMatches(results.Select(r => (r.Key, r.FieldMatches.SelectMany(m => m.Locations).ToList())));
+
+            results.Should().HaveCount(expectedResults.Count);
+
+            foreach (var (expectedId, expectedLocations) in expectedResults)
+            {
+                results.Single(r => r.Key == expectedId).FieldMatches.Should().SatisfyRespectively(
+                    x => x.Locations.Should().BeEquivalentTo(expectedLocations));
+            }
+        }
+
+        private void WriteMatches(IEnumerable<(int id, List<TokenLocation>)> results)
+        {
+            foreach (var result in results)
+            {
+                outputHelper.WriteLine("");
+                outputHelper.WriteLine("Item " + result.id);
+
+                foreach (var match in result.Item2)
+                {
+                    outputHelper.WriteLine($"index {match.TokenIndex} start {match.Start}: {this.fixture.IndexedText[result.id].Substring(match.Start, match.Length)}");
+                }
+
+            }
+        }
+    }
+}

--- a/test/Lifti.Tests/Tokenization/TokenizerTests.cs
+++ b/test/Lifti.Tests/Tokenization/TokenizerTests.cs
@@ -40,7 +40,7 @@ namespace Lifti.Tests.Tokenization
             output.Should().BeEmpty();
         }
 
-        protected static Tokenizer WithConfiguration(bool splitOnPunctuation = true, char[] additionalSplitChars = null, bool caseInsensitive = false, bool accentInsensitive = false)
+        protected static Tokenizer WithConfiguration(bool splitOnPunctuation = true, char[]? additionalSplitChars = null, bool caseInsensitive = false, bool accentInsensitive = false)
         {
             return new Tokenizer(
                 new TokenizationOptions()


### PR DESCRIPTION
Implements #34 

The query parser will now treat search terms prefixed with a `?` to be a fuzzy match, so `?vampyr` will match `vampire`.

This is implemented as an iterative search through the index keeping track of potential matches with transpositions, substitutions, deletions and insertions as it proceeds. Because of the essentially recursive nature of the search, placing some constraints on the number of variations is implemented both as:

* A maximum number of edits across the entire search term
* A maximum number of sequential edits

As soon as either of those constraints are breached, that particular search path is terminated.

Any matched tokens have their score multiplied by a weighting, calculated as `((L1 + L2)-E)/(L1 + L2)` where
* L1 = Search term length
* L2 = Matched term length
* E = The Levenshtein distance between the search term and match

So for a word with no edits, we have a weighting of ((L1 + L2)-0)/(L1 + L2) = 1

This means that words matched fuzzily still contribute to the overall score of a document, but at a reduced weight.

## Breaking changes

`IIndexNavigator.GetExactAndChildMatches`, `IIndexNavigator.GetExactMatches` and `IScorer.Score`  now take a new `weighting` parameter that should be used as a multiplier for the scores of any matches.