### PR TITLE
Adjacent words: prevent the same token matching with itself

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ trigger:
 variables:
   majorVersion: 3
   minorVersion: 0
-  patchVersion: 0
+  patchVersion: 1
   project: src/Lifti.Core/Lifti.Core.csproj
   testProject: test/Lifti.Tests/Lifti.Tests.csproj
   buildConfiguration: 'Release'

--- a/src/Lifti.Core/Lifti.Core.csproj
+++ b/src/Lifti.Core/Lifti.Core.csproj
@@ -15,7 +15,6 @@
     <PackageId>Lifti.Core</PackageId>
     <Copyright>Mike Goatly</Copyright>
     <PackageLicenseFile></PackageLicenseFile>
-    <PackageReleaseNotes>First version of the new rewrite</PackageReleaseNotes>
     <AssemblyName>Lifti.Core</AssemblyName>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Lifti.Core/Querying/IntegerExtensions.cs
+++ b/src/Lifti.Core/Querying/IntegerExtensions.cs
@@ -4,7 +4,7 @@
     {
         internal static bool IsPositiveAndLessThanOrEqualTo(this int value, int target)
         {
-            return value >= 0 && value <= target;
+            return value > 0 && value <= target;
         }
     }
 }

--- a/test/Lifti.Tests/Querying/QueryParts/AdjacentWordsQueryOperatorTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/AdjacentWordsQueryOperatorTests.cs
@@ -44,5 +44,24 @@ namespace Lifti.Tests.Querying.QueryParts
                 },
                 config => config.AllowingInfiniteRecursion());
         }
+
+        [Fact]
+        public void ShouldNotCombineSameTokensTogether()
+        {
+            var sut = new AdjacentWordsQueryOperator(
+                new[] {
+                    new FakeQueryPart(
+                        ScoredToken(7, ScoredFieldMatch(1D, 1, 8, 20, 100))),
+                    new FakeQueryPart(
+                        ScoredToken(7, ScoredFieldMatch(1D, 1, 8, 20, 100)))
+                    });
+
+            var results = sut.Evaluate(() => new FakeIndexNavigator(), QueryContext.Empty);
+
+            // Item 7 matches only:
+            // Field 1: ((8, 9), 10)
+            // The first and second query parts should not combine together
+            results.Matches.Should().BeEmpty();
+        }
     }
 }

--- a/test/Lifti.Tests/Querying/QueryParts/AdjacentWordsQueryOperatorTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/AdjacentWordsQueryOperatorTests.cs
@@ -58,8 +58,6 @@ namespace Lifti.Tests.Querying.QueryParts
 
             var results = sut.Evaluate(() => new FakeIndexNavigator(), QueryContext.Empty);
 
-            // Item 7 matches only:
-            // Field 1: ((8, 9), 10)
             // The first and second query parts should not combine together
             results.Matches.Should().BeEmpty();
         }


### PR DESCRIPTION
Fixes #44 