### PR TITLE
Refactoring tokenizer

### DIFF
--- a/src/Lifti.Core/ExceptionMessages.Designer.cs
+++ b/src/Lifti.Core/ExceptionMessages.Designer.cs
@@ -376,6 +376,15 @@ namespace Lifti {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Text tokens must have an associated index tokenizer.
+        /// </summary>
+        internal static string TextTokensMustHaveIndexTokenizers {
+            get {
+                return ResourceManager.GetString("TextTokensMustHaveIndexTokenizers", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to A timeout occurred waiting for index write lock.
         /// </summary>
         internal static string TimeoutWaitingForWriteLock {
@@ -399,6 +408,15 @@ namespace Lifti {
         internal static string UnableToReadHeaderInformation {
             get {
                 return ResourceManager.GetString("UnableToReadHeaderInformation", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unexpected close bracket encountered in query.
+        /// </summary>
+        internal static string UnexpectedCloseBracket {
+            get {
+                return ResourceManager.GetString("UnexpectedCloseBracket", resourceCulture);
             }
         }
         

--- a/src/Lifti.Core/ExceptionMessages.resx
+++ b/src/Lifti.Core/ExceptionMessages.resx
@@ -222,6 +222,9 @@
   <data name="SingleCharacterWildcardsFollowingMultiCharacterNotSupported" xml:space="preserve">
     <value>Single character wildcards (%) following a multi-character wildcard (*) are not currently supported.</value>
   </data>
+  <data name="TextTokensMustHaveIndexTokenizers" xml:space="preserve">
+    <value>Text tokens must have an associated index tokenizer</value>
+  </data>
   <data name="TimeoutWaitingForWriteLock" xml:space="preserve">
     <value>A timeout occurred waiting for index write lock</value>
   </data>
@@ -230,6 +233,9 @@
   </data>
   <data name="UnableToReadHeaderInformation" xml:space="preserve">
     <value>Unable to read header data from serialized index content.</value>
+  </data>
+  <data name="UnexpectedCloseBracket" xml:space="preserve">
+    <value>Unexpected close bracket encountered in query</value>
   </data>
   <data name="UnexpectedEndOfQuery" xml:space="preserve">
     <value>The query ended unexpectedly - a token was expected.</value>

--- a/src/Lifti.Core/FullTextIndex.cs
+++ b/src/Lifti.Core/FullTextIndex.cs
@@ -34,7 +34,7 @@ namespace Lifti
             IQueryParser queryParser,
             IIndexScorerFactory scorer,
             ITextExtractor defaultTextExtractor,
-            ITokenizer defaultTokenizer,
+            IIndexTokenizer defaultTokenizer,
             Func<IIndexSnapshot<TKey>, Task>[]? indexModifiedActions)
         {
             this.indexNavigatorPool = new IndexNavigatorPool(scorer);
@@ -85,7 +85,7 @@ namespace Lifti
         public IIndexSnapshot<TKey> Snapshot => this.currentSnapshot;
 
         /// <inheritdoc />
-        public ITokenizer DefaultTokenizer { get; }
+        public IIndexTokenizer DefaultTokenizer { get; }
 
         /// <inheritdoc />
         public ITextExtractor DefaultTextExtractor { get; }
@@ -234,7 +234,7 @@ namespace Lifti
             this.PerformWriteLockedAction(() => this.Root = indexNode);
         }
 
-        private static IReadOnlyList<Token> ExtractDocumentTokens(IEnumerable<string> documentTextFragments, ITextExtractor textExtractor, ITokenizer tokenizer)
+        private static IReadOnlyList<Token> ExtractDocumentTokens(IEnumerable<string> documentTextFragments, ITextExtractor textExtractor, IIndexTokenizer tokenizer)
         {
             var documentOffset = 0;
             var fragments = Enumerable.Empty<DocumentTextFragment>();
@@ -247,7 +247,7 @@ namespace Lifti
             return tokenizer.Process(fragments);
         }
 
-        private static IReadOnlyList<Token> ExtractDocumentTokens(string documentText, ITextExtractor textExtractor, ITokenizer tokenizer)
+        private static IReadOnlyList<Token> ExtractDocumentTokens(string documentText, ITextExtractor textExtractor, IIndexTokenizer tokenizer)
         {
             var fragments = textExtractor.Extract(documentText.AsMemory(), 0);
             return tokenizer.Process(fragments);

--- a/src/Lifti.Core/FullTextIndex.cs
+++ b/src/Lifti.Core/FullTextIndex.cs
@@ -91,6 +91,9 @@ namespace Lifti
         public ITextExtractor DefaultTextExtractor { get; }
 
         /// <inheritdoc />
+        IIndexTokenizer IIndexTokenizerProvider.this[string fieldName] => this.FieldLookup.GetFieldInfo(fieldName).Tokenizer;
+
+        /// <inheritdoc />
         public IIndexNavigator CreateNavigator()
         {
             return this.Snapshot.CreateNavigator();
@@ -208,7 +211,7 @@ namespace Lifti
         /// <inheritdoc />
         public IEnumerable<SearchResult<TKey>> Search(string searchText)
         {
-            var query = this.queryParser.Parse(this.FieldLookup, searchText, this.DefaultTokenizer);
+            var query = this.queryParser.Parse(this.FieldLookup, searchText, this);
             return query.Execute(this.currentSnapshot);
         }
 

--- a/src/Lifti.Core/FullTextIndexBuilder.cs
+++ b/src/Lifti.Core/FullTextIndexBuilder.cs
@@ -18,7 +18,7 @@ namespace Lifti
         private readonly IndexOptions advancedOptions = new IndexOptions();
         private IIndexScorerFactory? scorerFactory;
         private IQueryParser? queryParser;
-        private ITokenizer defaultTokenizer = Tokenizer.Default;
+        private IIndexTokenizer defaultTokenizer = IndexTokenizer.Default;
         private List<Func<IIndexSnapshot<TKey>, Task>>? indexModifiedActions;
         private ITextExtractor? defaultTextExtractor;
 

--- a/src/Lifti.Core/FullTextIndexExtensions.cs
+++ b/src/Lifti.Core/FullTextIndexExtensions.cs
@@ -11,7 +11,7 @@ namespace Lifti
     {
         /// <summary>
         /// Parses the given <paramref name="queryText"/> using the index's <see cref="IQueryParser"/>
-        /// and default <see cref="ITokenizer"/>.
+        /// and default <see cref="IIndexTokenizer"/>.
         /// </summary>
         public static IQuery ParseQuery<TKey>(this IFullTextIndex<TKey> index, string queryText)
         {

--- a/src/Lifti.Core/FullTextIndexExtensions.cs
+++ b/src/Lifti.Core/FullTextIndexExtensions.cs
@@ -17,7 +17,7 @@ namespace Lifti
         {
             return index is null
                 ? throw new ArgumentNullException(nameof(index))
-                : index.QueryParser.Parse(index.FieldLookup, queryText, index.DefaultTokenizer);
+                : index.QueryParser.Parse(index.FieldLookup, queryText, index);
         }
     }
 }

--- a/src/Lifti.Core/IFullTextIndex.cs
+++ b/src/Lifti.Core/IFullTextIndex.cs
@@ -8,7 +8,7 @@ namespace Lifti
 {
     /// <summary>
     /// </summary>
-    public interface IFullTextIndex<TKey>
+    public interface IFullTextIndex<TKey> : IIndexTokenizerProvider
     {
         /// <summary>
         /// Internally an index keeps track of items and their metadata. Can be used get ids for items and 
@@ -33,12 +33,6 @@ namespace Lifti
         /// whilst it is being mutated.
         /// </summary>
         IIndexSnapshot<TKey> Snapshot { get; }
-
-        /// <summary>
-        /// Gets the default <see cref="IIndexTokenizer"/> implementation that the index will use when one is
-        /// not explicitly configured for a field.
-        /// </summary>
-        IIndexTokenizer DefaultTokenizer { get; }
 
         /// <summary>
         /// Gets the configured <see cref="IQueryParser"/> for the index. If you need to execute the same query against the index multiple

--- a/src/Lifti.Core/IFullTextIndex.cs
+++ b/src/Lifti.Core/IFullTextIndex.cs
@@ -35,10 +35,10 @@ namespace Lifti
         IIndexSnapshot<TKey> Snapshot { get; }
 
         /// <summary>
-        /// Gets the default <see cref="ITokenizer"/> implementation that the index will use when one is
+        /// Gets the default <see cref="IIndexTokenizer"/> implementation that the index will use when one is
         /// not explicitly configured for a field.
         /// </summary>
-        ITokenizer DefaultTokenizer { get; }
+        IIndexTokenizer DefaultTokenizer { get; }
 
         /// <summary>
         /// Gets the configured <see cref="IQueryParser"/> for the index. If you need to execute the same query against the index multiple

--- a/src/Lifti.Core/IIndexTokenizerProvider.cs
+++ b/src/Lifti.Core/IIndexTokenizerProvider.cs
@@ -1,0 +1,22 @@
+﻿using Lifti.Tokenization;
+
+namespace Lifti
+{
+    /// <summary>
+    /// Implemented by classes that can provide access to the various <see cref="IIndexTokenizer"/> implementations
+    /// used in an <see cref="IFullTextIndex{TKey}"/>.
+    /// </summary>
+    public interface IIndexTokenizerProvider
+    {
+        /// <summary>
+        /// Gets the default <see cref="IIndexTokenizer"/> implementation that the index will use when one is
+        /// not explicitly configured for a field.
+        /// </summary>
+        IIndexTokenizer DefaultTokenizer { get; }
+
+        /// <summary>
+        /// Gets the <see cref="IIndexTokenizer"/> for the given field.
+        /// </summary>
+        IIndexTokenizer this[string fieldName] { get; }
+    }
+}

--- a/src/Lifti.Core/IIndexedFieldLookup.cs
+++ b/src/Lifti.Core/IIndexedFieldLookup.cs
@@ -17,8 +17,8 @@
         string GetFieldForId(byte id);
 
         /// <summary>
-        /// Gets the configuration required for indexing a named field, including the <see cref="Lifti.Tokenization.TextExtraction.ITextExtractor"/>
-        /// and <see cref="Lifti.Tokenization.IIndexTokenizer"/> instances to use when processing the field's text.
+        /// Gets the configuration required for indexing a named field, including the <see cref="Tokenization.TextExtraction.ITextExtractor"/>
+        /// and <see cref="Tokenization.IIndexTokenizer"/> instances to use when processing the field's text.
         /// </summary>
         IndexedFieldDetails GetFieldInfo(string fieldName);
     }

--- a/src/Lifti.Core/IIndexedFieldLookup.cs
+++ b/src/Lifti.Core/IIndexedFieldLookup.cs
@@ -18,7 +18,7 @@
 
         /// <summary>
         /// Gets the configuration required for indexing a named field, including the <see cref="Lifti.Tokenization.TextExtraction.ITextExtractor"/>
-        /// and <see cref="Lifti.Tokenization.ITokenizer"/> instances to use when processing the field's text.
+        /// and <see cref="Lifti.Tokenization.IIndexTokenizer"/> instances to use when processing the field's text.
         /// </summary>
         IndexedFieldDetails GetFieldInfo(string fieldName);
     }

--- a/src/Lifti.Core/IndexedFieldDetails.cs
+++ b/src/Lifti.Core/IndexedFieldDetails.cs
@@ -9,7 +9,7 @@ namespace Lifti
     /// </summary>
     public struct IndexedFieldDetails : IEquatable<IndexedFieldDetails>
     {
-        internal IndexedFieldDetails(byte id, ITextExtractor textExtractor, ITokenizer tokenizer)
+        internal IndexedFieldDetails(byte id, ITextExtractor textExtractor, IIndexTokenizer tokenizer)
         {
             this.Id = id;
             this.TextExtractor = textExtractor;
@@ -27,9 +27,9 @@ namespace Lifti
         public ITextExtractor TextExtractor { get; }
 
         /// <summary>
-        /// The <see cref="ITokenizer"/> that should be used when tokenizing text for the field.
+        /// The <see cref="IIndexTokenizer"/> that should be used when tokenizing text for the field.
         /// </summary>
-        public ITokenizer Tokenizer { get; }
+        public IIndexTokenizer Tokenizer { get; }
 
         /// <inheritdoc />
         public override bool Equals(object obj)
@@ -52,7 +52,7 @@ namespace Lifti
             return HashCode.Combine(this.Id, this.Tokenizer, this.TextExtractor);
         }
 
-        internal void Deconstruct(out byte fieldId, out ITextExtractor textExtractor, out ITokenizer tokenizer)
+        internal void Deconstruct(out byte fieldId, out ITextExtractor textExtractor, out IIndexTokenizer tokenizer)
         {
             fieldId = this.Id;
             tokenizer = this.Tokenizer;

--- a/src/Lifti.Core/IndexedFieldLookup.cs
+++ b/src/Lifti.Core/IndexedFieldLookup.cs
@@ -17,7 +17,7 @@ namespace Lifti
         internal IndexedFieldLookup(
             IEnumerable<IFieldReader> fieldReaders, 
             ITextExtractor defaultTextExtractor,
-            ITokenizer defaultTokenizer)
+            IIndexTokenizer defaultTokenizer)
         {
             if (fieldReaders is null)
             {
@@ -69,7 +69,7 @@ namespace Lifti
             return details;
         }
 
-        private void RegisterField(IFieldReader fieldOptions, ITextExtractor defaultTextExtractor, ITokenizer defaultTokenizer)
+        private void RegisterField(IFieldReader fieldOptions, ITextExtractor defaultTextExtractor, IIndexTokenizer defaultTokenizer)
         {
             var fieldName = fieldOptions.Name;
             if (this.fieldToDetailsLookup.ContainsKey(fieldOptions.Name))

--- a/src/Lifti.Core/Querying/IQueryParser.cs
+++ b/src/Lifti.Core/Querying/IQueryParser.cs
@@ -9,7 +9,7 @@ namespace Lifti.Querying
     {
         /// <summary>
         /// Parses the<see cref="IQuery"/> implementation that represents the <paramref name="queryText"/>. The value
-        /// in <paramref name="queryText"/> is tokenized using the provided <see cref="ITokenizer"/>.
+        /// in <paramref name="queryText"/> is tokenized using the provided <see cref="IIndexTokenizer"/>.
         /// </summary>
         /// <param name="fieldLookup">
         /// The <see cref="IIndexedFieldLookup"/> to used to obtain information about fields
@@ -19,11 +19,11 @@ namespace Lifti.Querying
         /// The text of the query to parse.
         /// </param>
         /// <param name="tokenizer">
-        /// The <see cref="ITokenizer"/> to use when parsing tokens out of the <paramref name="queryText"/>.
+        /// The <see cref="IIndexTokenizer"/> to use when parsing tokens out of the <paramref name="queryText"/>.
         /// </param>
         /// <returns>
         /// The parsed <see cref="IQuery"/> representation of the query.
         /// </returns>
-        IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, ITokenizer tokenizer);
+        IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizer tokenizer);
     }
 }

--- a/src/Lifti.Core/Querying/IQueryParser.cs
+++ b/src/Lifti.Core/Querying/IQueryParser.cs
@@ -18,12 +18,12 @@ namespace Lifti.Querying
         /// <param name="queryText">
         /// The text of the query to parse.
         /// </param>
-        /// <param name="tokenizer">
-        /// The <see cref="IIndexTokenizer"/> to use when parsing tokens out of the <paramref name="queryText"/>.
+        /// <param name="tokenizerProvider">
+        /// The <see cref="IIndexTokenizerProvider"/> to use when accessing the tokenizers associated to the index being queried.
         /// </param>
         /// <returns>
         /// The parsed <see cref="IQuery"/> representation of the query.
         /// </returns>
-        IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizer tokenizer);
+        IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizerProvider tokenizerProvider);
     }
 }

--- a/src/Lifti.Core/Querying/IQueryTokenizer.cs
+++ b/src/Lifti.Core/Querying/IQueryTokenizer.cs
@@ -15,11 +15,11 @@ namespace Lifti.Querying
         /// The text to parse.
         /// </param>
         /// <param name="tokenizer">
-        /// The <see cref="ITokenizer"/> for the field the query is being parsed for.
+        /// The <see cref="IIndexTokenizer"/> for the field the query is being parsed for.
         /// </param>
         /// <returns>
         /// The parsed <see cref="QueryToken"/>s.
         /// </returns>
-        IEnumerable<QueryToken> ParseQueryTokens(string queryText, ITokenizer tokenizer);
+        IEnumerable<QueryToken> ParseQueryTokens(string queryText, IIndexTokenizer tokenizer);
     }
 }

--- a/src/Lifti.Core/Querying/IQueryTokenizer.cs
+++ b/src/Lifti.Core/Querying/IQueryTokenizer.cs
@@ -14,12 +14,12 @@ namespace Lifti.Querying
         /// <param name="queryText">
         /// The text to parse.
         /// </param>
-        /// <param name="tokenizer">
-        /// The <see cref="IIndexTokenizer"/> for the field the query is being parsed for.
+        /// <param name="tokenizerProvider">
+        /// The <see cref="IIndexTokenizerProvider"/> used to access the various <see cref="IIndexTokenizer"/> instances associated to the index.
         /// </param>
         /// <returns>
         /// The parsed <see cref="QueryToken"/>s.
         /// </returns>
-        IEnumerable<QueryToken> ParseQueryTokens(string queryText, IIndexTokenizer tokenizer);
+        IEnumerable<QueryToken> ParseQueryTokens(string queryText, IIndexTokenizerProvider tokenizerProvider);
     }
 }

--- a/src/Lifti.Core/Querying/QueryParser.cs
+++ b/src/Lifti.Core/Querying/QueryParser.cs
@@ -26,7 +26,7 @@ namespace Lifti.Querying
         }
 
         /// <inheritdoc />
-        public IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, ITokenizer tokenizer)
+        public IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizer tokenizer)
         {
             if (fieldLookup is null)
             {
@@ -48,7 +48,7 @@ namespace Lifti.Querying
             IIndexedFieldLookup fieldLookup,
             QueryParserState state,
             QueryToken token,
-            ITokenizer tokenizer,
+            IIndexTokenizer tokenizer,
             IQueryPart? currentQuery)
         {
             switch (token.TokenType)
@@ -99,7 +99,7 @@ namespace Lifti.Querying
             }
         }
 
-        private IQueryPart CreateWordQueryPart(QueryToken queryToken, ITokenizer tokenizer)
+        private IQueryPart CreateWordQueryPart(QueryToken queryToken, IIndexTokenizer tokenizer)
         {
             if (queryToken.TokenType != QueryTokenType.Text)
             {
@@ -212,7 +212,7 @@ namespace Lifti.Querying
         {
             private readonly IEnumerator<QueryToken> enumerator;
 
-            public QueryParserState(IQueryTokenizer queryTokenizer, ITokenizer tokenizer, string queryText)
+            public QueryParserState(IQueryTokenizer queryTokenizer, IIndexTokenizer tokenizer, string queryText)
             {
                 this.enumerator = queryTokenizer.ParseQueryTokens(queryText, tokenizer).GetEnumerator();
             }

--- a/src/Lifti.Core/Querying/QueryParser.cs
+++ b/src/Lifti.Core/Querying/QueryParser.cs
@@ -2,6 +2,7 @@
 using Lifti.Tokenization;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Lifti.Querying
@@ -26,7 +27,7 @@ namespace Lifti.Querying
         }
 
         /// <inheritdoc />
-        public IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizer tokenizer)
+        public IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizerProvider tokenizerProvider)
         {
             if (fieldLookup is null)
             {
@@ -35,10 +36,10 @@ namespace Lifti.Querying
 
             IQueryPart? rootPart = null;
 
-            var state = new QueryParserState(this.queryTokenizer, tokenizer, queryText);
+            var state = new QueryParserState(this.queryTokenizer, tokenizerProvider, queryText);
             while (state.TryGetNextToken(out var token))
             {
-                rootPart = this.CreateQueryPart(fieldLookup, state, token, tokenizer, rootPart);
+                rootPart = this.CreateQueryPart(fieldLookup, state, token, rootPart);
             }
 
             return new Query(rootPart ?? EmptyQueryPart.Instance);
@@ -48,17 +49,16 @@ namespace Lifti.Querying
             IIndexedFieldLookup fieldLookup,
             QueryParserState state,
             QueryToken token,
-            IIndexTokenizer tokenizer,
             IQueryPart? currentQuery)
         {
             switch (token.TokenType)
             {
                 case QueryTokenType.Text:
-                    return this.ComposePart(currentQuery, this.CreateWordQueryPart(token, tokenizer));
+                    return this.ComposePart(currentQuery, this.CreateWordQueryPart(token));
 
                 case QueryTokenType.FieldFilter:
-                    var (fieldId, _, fieldTokenizer) = fieldLookup.GetFieldInfo(token.TokenText);
-                    var filteredPart = this.CreateQueryPart(fieldLookup, state, state.GetNextToken(), fieldTokenizer, null);
+                    var (fieldId, _, _) = fieldLookup.GetFieldInfo(token.TokenText);
+                    var filteredPart = this.CreateQueryPart(fieldLookup, state, state.GetNextToken(), null);
                     return this.ComposePart(
                         currentQuery,
                         new FieldFilterQueryOperator(token.TokenText, fieldId, filteredPart));
@@ -68,12 +68,12 @@ namespace Lifti.Querying
                 case QueryTokenType.NearOperator:
                 case QueryTokenType.PrecedingNearOperator:
                 case QueryTokenType.PrecedingOperator:
-                    var rightPart = this.CreateQueryPart(fieldLookup, state, state.GetNextToken(), tokenizer, null);
+                    var rightPart = this.CreateQueryPart(fieldLookup, state, state.GetNextToken(), null);
                     return CombineParts(currentQuery, rightPart, token.TokenType, token.Tolerance);
 
                 case QueryTokenType.OpenBracket:
                     var bracketedPart = state.GetTokensUntil(QueryTokenType.CloseBracket)
-                        .Aggregate((IQueryPart?)null, (current, next) => this.CreateQueryPart(fieldLookup, state, next, tokenizer, current));
+                        .Aggregate((IQueryPart?)null, (current, next) => this.CreateQueryPart(fieldLookup, state, next, current));
 
                     if (bracketedPart == null)
                     {
@@ -84,7 +84,7 @@ namespace Lifti.Querying
 
                 case QueryTokenType.BeginAdjacentTextOperator:
                     var tokens = state.GetTokensUntil(QueryTokenType.EndAdjacentTextOperator)
-                        .Select(t => this.CreateWordQueryPart(t, tokenizer))
+                        .Select(this.CreateWordQueryPart)
                         .ToList();
 
                     if (tokens.Count == 0)
@@ -99,18 +99,20 @@ namespace Lifti.Querying
             }
         }
 
-        private IQueryPart CreateWordQueryPart(QueryToken queryToken, IIndexTokenizer tokenizer)
+        private IQueryPart CreateWordQueryPart(QueryToken queryToken)
         {
             if (queryToken.TokenType != QueryTokenType.Text)
             {
                 throw new QueryParserException(ExceptionMessages.ExpectedTextToken, queryToken.TokenType);
             }
 
+            var indexTokenizer = queryToken.IndexTokenizer ?? throw new InvalidOperationException(ExceptionMessages.TextTokensMustHaveIndexTokenizers);
+
             var tokenText = queryToken.TokenText.AsSpan();
 
             var fuzzyMatchInfo = ExplicitFuzzySearchTerm.Parse(tokenText);
 
-            if (!fuzzyMatchInfo.IsFuzzyMatch && WildcardQueryPartParser.TryParse(tokenText, tokenizer, out var wildcardQueryPart))
+            if (!fuzzyMatchInfo.IsFuzzyMatch && WildcardQueryPartParser.TryParse(tokenText, indexTokenizer, out var wildcardQueryPart))
             {
                 return wildcardQueryPart;
             }
@@ -123,7 +125,7 @@ namespace Lifti.Querying
             IEnumerable<IQueryPart> result;
             if (fuzzyMatchInfo.IsFuzzyMatch || this.options.AssumeFuzzySearchTerms)
             {
-                result = tokenizer.Process(fuzzyMatchInfo.IsFuzzyMatch ? tokenText.Slice(fuzzyMatchInfo.SearchTermStartIndex) : tokenText)
+                result = indexTokenizer.Process(fuzzyMatchInfo.IsFuzzyMatch ? tokenText.Slice(fuzzyMatchInfo.SearchTermStartIndex) : tokenText)
                  .Select(
                     token => new FuzzyMatchQueryPart(
                         token.Value,
@@ -132,7 +134,7 @@ namespace Lifti.Querying
             }
             else
             {
-                result = tokenizer.Process(tokenText)
+                result = indexTokenizer.Process(tokenText)
                      .Select(token => new ExactWordQueryPart(token.Value));
             }
 
@@ -212,12 +214,12 @@ namespace Lifti.Querying
         {
             private readonly IEnumerator<QueryToken> enumerator;
 
-            public QueryParserState(IQueryTokenizer queryTokenizer, IIndexTokenizer tokenizer, string queryText)
+            public QueryParserState(IQueryTokenizer queryTokenizer, IIndexTokenizerProvider tokenizerProvider, string queryText)
             {
-                this.enumerator = queryTokenizer.ParseQueryTokens(queryText, tokenizer).GetEnumerator();
+                this.enumerator = queryTokenizer.ParseQueryTokens(queryText, tokenizerProvider).GetEnumerator();
             }
 
-            public bool TryGetNextToken(out QueryToken token)
+            public bool TryGetNextToken([NotNullWhen(true)]out QueryToken? token)
             {
                 if (this.enumerator.MoveNext())
                 {

--- a/src/Lifti.Core/Querying/QueryParserBuilder.cs
+++ b/src/Lifti.Core/Querying/QueryParserBuilder.cs
@@ -87,7 +87,7 @@ namespace Lifti.Querying
         }
 
         /// <summary>
-        /// Builds an <see cref="ITokenizer"/> instance matching the current configuration.
+        /// Builds an <see cref="IIndexTokenizer"/> instance matching the current configuration.
         /// </summary>
         public IQueryParser Build()
         {

--- a/src/Lifti.Core/Querying/QueryToken.cs
+++ b/src/Lifti.Core/Querying/QueryToken.cs
@@ -1,17 +1,19 @@
-﻿using System;
+﻿using Lifti.Tokenization;
+using System;
 
 namespace Lifti.Querying
 {
     /// <summary>
     /// A token parsed from a query string.
     /// </summary>
-    public struct QueryToken : IEquatable<QueryToken>
+    internal class QueryToken : IEquatable<QueryToken>
     {
-        private QueryToken(string tokenText, QueryTokenType tokenType, int tolerance)
+        private QueryToken(string tokenText, QueryTokenType tokenType, int tolerance, IIndexTokenizer? indexTokenizer)
         {
             this.TokenText = tokenText;
             this.TokenType = tokenType;
             this.Tolerance = tolerance;
+            this.IndexTokenizer = indexTokenizer;
         }
 
         /// <summary>
@@ -29,6 +31,11 @@ namespace Lifti.Querying
         public int Tolerance { get; }
 
         /// <summary>
+        /// The <see cref="IIndexTokenizer"/> to use when further tokenizing the text in this instance.
+        /// </summary>
+        public IIndexTokenizer? IndexTokenizer { get; }
+
+        /// <summary>
         /// Gets the <see cref="QueryTokenType"/> that this instance represents.
         /// </summary>
         public QueryTokenType TokenType { get; }
@@ -39,7 +46,10 @@ namespace Lifti.Querying
         /// <param name="text">
         /// The text to be matched by the query.
         /// </param>
-        public static QueryToken ForText(string text) => new QueryToken(text, QueryTokenType.Text, 0);
+        /// <param name="indexTokenizer">
+        /// The <see cref="IIndexTokenizer"/> to use when further tokenizing the captured text. 
+        /// </param>
+        public static QueryToken ForText(string text, IIndexTokenizer indexTokenizer) => new QueryToken(text, QueryTokenType.Text, 0, indexTokenizer);
 
         /// <summary>
         /// Creates a new <see cref="QueryToken"/> instance representing a field filter.
@@ -47,7 +57,7 @@ namespace Lifti.Querying
         /// <param name="fieldName">
         /// The name of the field to match.
         /// </param>
-        public static QueryToken ForFieldFilter(string fieldName) => new QueryToken(fieldName, QueryTokenType.FieldFilter, 0);
+        public static QueryToken ForFieldFilter(string fieldName) => new QueryToken(fieldName, QueryTokenType.FieldFilter, 0, null);
 
         /// <summary>
         /// Creates a new <see cref="QueryToken"/> instance representing a query operator.
@@ -55,7 +65,7 @@ namespace Lifti.Querying
         /// <param name="operatorType">
         /// The type of operator the token should represent.
         /// </param>
-        public static QueryToken ForOperator(QueryTokenType operatorType) => new QueryToken(string.Empty, operatorType, 0);
+        public static QueryToken ForOperator(QueryTokenType operatorType) => new QueryToken(string.Empty, operatorType, 0, null);
 
         /// <summary>
         /// Creates a new <see cref="QueryToken"/> instance representing a query operator that has additional positional constraints.
@@ -67,7 +77,7 @@ namespace Lifti.Querying
         /// The number of tokens to use as the tolerance for the operator.
         /// </param>
         public static QueryToken ForOperatorWithTolerance(QueryTokenType operatorType, int tolerance) => 
-            new QueryToken(string.Empty, operatorType, tolerance == 0 ? 5 : tolerance);
+            new QueryToken(string.Empty, operatorType, tolerance == 0 ? 5 : tolerance, null);
 
         /// <inheritdoc />
         public override bool Equals(object obj)

--- a/src/Lifti.Core/Querying/QueryTokenizer.cs
+++ b/src/Lifti.Core/Querying/QueryTokenizer.cs
@@ -58,7 +58,7 @@ namespace Lifti.Querying
         }
 
         /// <inheritdoc />
-        public IEnumerable<QueryToken> ParseQueryTokens(string queryText, ITokenizer tokenizer)
+        public IEnumerable<QueryToken> ParseQueryTokens(string queryText, IIndexTokenizer tokenizer)
         {
             if (queryText is null)
             {
@@ -252,7 +252,7 @@ namespace Lifti.Querying
             }
         }
 
-        private static bool IsSplitChar(char current, QueryTokenizerState state, ITokenizer tokenizer)
+        private static bool IsSplitChar(char current, QueryTokenizerState state, IIndexTokenizer tokenizer)
         {
             var isWhitespace = char.IsWhiteSpace(current);
             return state.OperatorState switch

--- a/src/Lifti.Core/Querying/QueryTokenizer.cs
+++ b/src/Lifti.Core/Querying/QueryTokenizer.cs
@@ -1,6 +1,7 @@
 ﻿using Lifti.Tokenization;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Lifti.Querying
 {
@@ -51,21 +52,82 @@ namespace Lifti.Querying
             ProcessingFuzzyMatchTerm = 2,
         }
 
-        private record QueryTokenizerState()
+        private record IndexTokenizerStackState(int BracketCaptureDepth, IIndexTokenizer IndexTokenizer);
+
+        private record QueryTokenizerState(IIndexTokenizer IndexTokenizer)
         {
             public OperatorParseState OperatorState { get; init; } = OperatorParseState.None;
             public TokenParseState TokenState { get; init; } = TokenParseState.None;
+            public int BracketDepth { get; init; }
+
+            private ImmutableStack<IndexTokenizerStackState> TokenizerStack { get; init; } = ImmutableStack<IndexTokenizerStackState>.Empty;
+
+            public QueryTokenizerState OpenBracket()
+            {
+                return this with
+                {
+                    BracketDepth = this.BracketDepth + 1
+                };
+            }
+
+            public QueryTokenizerState CloseBracket()
+            {
+                return this.BracketDepth > 0
+                    ? (this with
+                    {
+                        BracketDepth = this.BracketDepth - 1
+                    })
+                    : throw new QueryParserException(ExceptionMessages.UnexpectedCloseBracket);
+            }
+
+            public QueryTokenizerState PushTokenizer(IIndexTokenizer tokenizer)
+            {
+                return this with
+                {
+                    IndexTokenizer = tokenizer,
+                    TokenizerStack = this.TokenizerStack.Push(new IndexTokenizerStackState(this.BracketDepth, this.IndexTokenizer))
+                };
+            }
+
+            public QueryTokenizerState UpdateForYieldedToken()
+            {
+                if (this.OperatorState != OperatorParseState.ProcessingString && this.TokenizerStack.IsEmpty == false)
+                {
+                    var peeked = this.TokenizerStack.Peek();
+                    if (peeked.BracketCaptureDepth >= this.BracketDepth)
+                    {
+                        // We've reached the same bracket depth now that the tokenizer was captured at, so revert to the
+                        // previous one on the stack.
+                        var poppedStack = this.TokenizerStack.Pop(out var previousState);
+
+                        return this with
+                        {
+                            IndexTokenizer = previousState.IndexTokenizer,
+                            TokenizerStack = poppedStack
+                        };
+                    }
+                }
+
+                // Once token processing complete, reset any token state flags
+                if (this.TokenState != TokenParseState.None)
+                {
+                    return this with { TokenState = TokenParseState.None };
+                }
+
+                // We're still deeper in brackets than when we first captured the tokenizer, so don't revert
+                return this;
+            }
         }
 
         /// <inheritdoc />
-        public IEnumerable<QueryToken> ParseQueryTokens(string queryText, IIndexTokenizer tokenizer)
+        public IEnumerable<QueryToken> ParseQueryTokens(string queryText, IIndexTokenizerProvider tokenizerProvider)
         {
             if (queryText is null)
             {
                 throw new ArgumentNullException(nameof(queryText));
             }
 
-            var state = new QueryTokenizerState();
+            var state = new QueryTokenizerState(tokenizerProvider.DefaultTokenizer);
             var tokenStart = (int?)null;
             var tolerance = 0;
 
@@ -74,14 +136,10 @@ namespace Lifti.Querying
                 if (tokenStart != null)
                 {
                     var tokenText = queryText.Substring(tokenStart.Value, endIndex - tokenStart.Value);
-                    var token = QueryToken.ForText(tokenText);
+                    var token = QueryToken.ForText(tokenText, state.IndexTokenizer);
                     tokenStart = null;
 
-                    // Once token processing complete, reset any token state flags
-                    if (state.TokenState != TokenParseState.None)
-                    {
-                        state = state with { TokenState = TokenParseState.None };
-                    }
+                    state = state.UpdateForYieldedToken();
 
                     if (tokenText.Length == 0 || (tokenText[0] == '?' && tokenText[tokenText.Length - 1] == '?'))
                     {
@@ -111,12 +169,12 @@ namespace Lifti.Querying
                     state = state with { TokenState = TokenParseState.ProcessingFuzzyMatchTerm };
                 }
 
-                if (IsSplitChar(current, state, tokenizer))
+                if (IsSplitChar(current, state))
                 {
                     token = CreateTokenForYielding(i);
-                    if (token != null)
+                    if (token is not null)
                     {
-                        yield return token.Value;
+                        yield return token;
                     }
                 }
                 else
@@ -159,20 +217,26 @@ namespace Lifti.Querying
                                         throw new QueryParserException(ExceptionMessages.UnexpectedOperator, "=");
                                     }
 
-                                    yield return QueryToken.ForFieldFilter(queryText.Substring(tokenStart.Value, i - tokenStart.Value));
+                                    var fieldName = queryText.Substring(tokenStart.Value, i - tokenStart.Value);
+                                    yield return QueryToken.ForFieldFilter(fieldName);
+
+                                    state = state.PushTokenizer(tokenizerProvider[fieldName]);
+
                                     tokenStart = null;
                                     break;
                                 case ')':
+                                    state = state.CloseBracket();
                                     token = CreateTokenForYielding(i);
-                                    if (token != null)
+                                    if (token is not null)
                                     {
-                                        yield return token.Value;
+                                        yield return token;
                                     }
 
                                     yield return QueryToken.ForOperator(QueryTokenType.CloseBracket);
                                     break;
                                 case '(':
                                     yield return QueryToken.ForOperator(QueryTokenType.OpenBracket);
+                                    state = state.OpenBracket();
                                     break;
                                 case '~':
                                     tolerance = 0;
@@ -195,9 +259,9 @@ namespace Lifti.Querying
                                 case '"':
                                     state = state with { OperatorState = OperatorParseState.None };
                                     token = CreateTokenForYielding(i);
-                                    if (token != null)
+                                    if (token is not null)
                                     {
-                                        yield return token.Value;
+                                        yield return token;
                                     }
 
                                     yield return QueryToken.ForOperator(QueryTokenType.EndAdjacentTextOperator);
@@ -245,14 +309,14 @@ namespace Lifti.Querying
             if (tokenStart != null)
             {
                 token = CreateTokenForYielding(queryText.Length);
-                if (token != null)
+                if (token is not null)
                 {
-                    yield return token.GetValueOrDefault();
+                    yield return token;
                 }
             }
         }
 
-        private static bool IsSplitChar(char current, QueryTokenizerState state, IIndexTokenizer tokenizer)
+        private static bool IsSplitChar(char current, QueryTokenizerState state)
         {
             var isWhitespace = char.IsWhiteSpace(current);
             return state.OperatorState switch
@@ -260,11 +324,11 @@ namespace Lifti.Querying
                 OperatorParseState.None =>
                     isWhitespace || // Whitespace is always a split character
                     (!generalNonSplitPunctuation.Contains(current)
-                        && tokenizer.IsSplitCharacter(current) // Defer to the tokenizer for the field as to whether this is a split character,
+                        && state.IndexTokenizer.IsSplitCharacter(current) // Defer to the tokenizer for the field as to whether this is a split character,
                         && !(state.TokenState == TokenParseState.ProcessingFuzzyMatch && current == ',')), // ..unless it's a comma appearing in the first part of a fuzzy match
 
                 OperatorParseState.ProcessingString => isWhitespace ||
-                    (!quotedSectionNonSplitPunctuation.Contains(current) && tokenizer.IsSplitCharacter(current)),
+                    (!quotedSectionNonSplitPunctuation.Contains(current) && state.IndexTokenizer.IsSplitCharacter(current)),
 
                 // When processing a near operator, no splitting is possible until the operator processing is complete
                 OperatorParseState.ProcessingNearOperator => false,

--- a/src/Lifti.Core/Querying/SimpleQueryParser.cs
+++ b/src/Lifti.Core/Querying/SimpleQueryParser.cs
@@ -26,19 +26,19 @@ namespace Lifti.Querying
         }
 
         /// <inheritdoc />
-        public IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizer tokenizer)
+        public IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizerProvider tokenizerProvider)
         {
             if (queryText is null)
             {
                 throw new ArgumentNullException(nameof(queryText));
             }
 
-            if (tokenizer is null)
+            if (tokenizerProvider is null)
             {
-                throw new ArgumentNullException(nameof(tokenizer));
+                throw new ArgumentNullException(nameof(tokenizerProvider));
             }
 
-            var tokens = tokenizer.Process(queryText.AsSpan());
+            var tokens = tokenizerProvider.DefaultTokenizer.Process(queryText.AsSpan());
             if (tokens.Count == 0)
             {
                 return Query.Empty;

--- a/src/Lifti.Core/Querying/SimpleQueryParser.cs
+++ b/src/Lifti.Core/Querying/SimpleQueryParser.cs
@@ -26,7 +26,7 @@ namespace Lifti.Querying
         }
 
         /// <inheritdoc />
-        public IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, ITokenizer tokenizer)
+        public IQuery Parse(IIndexedFieldLookup fieldLookup, string queryText, IIndexTokenizer tokenizer)
         {
             if (queryText is null)
             {

--- a/src/Lifti.Core/Querying/WildcardQueryPartParser.cs
+++ b/src/Lifti.Core/Querying/WildcardQueryPartParser.cs
@@ -8,7 +8,7 @@ namespace Lifti.Querying
 {
     internal static class WildcardQueryPartParser
     {
-        public static bool TryParse(ReadOnlySpan<char> token, ITokenizer tokenizer, [NotNullWhen(true)] out WildcardQueryPart? part)
+        public static bool TryParse(ReadOnlySpan<char> token, IIndexTokenizer tokenizer, [NotNullWhen(true)] out WildcardQueryPart? part)
         {
             List<WildcardQueryFragment>? fragments = null;
             void AddFragment(WildcardQueryFragment fragment)

--- a/src/Lifti.Core/Tokenization/IIndexTokenizer.cs
+++ b/src/Lifti.Core/Tokenization/IIndexTokenizer.cs
@@ -5,9 +5,9 @@ using System.Collections.Generic;
 namespace Lifti.Tokenization
 {
     /// <summary>
-    /// Defines methods for processing inputs strings to a set of <see cref="Token"/> instances.
+    /// Defines methods for processing text for use in an index.
     /// </summary>
-    public interface ITokenizer
+    public interface IIndexTokenizer
     {
         /// <summary>
         /// Tokenizes the given <see cref="DocumentTextFragment"/>s relating a single document.

--- a/src/Lifti.Core/Tokenization/IndexTokenizer.cs
+++ b/src/Lifti.Core/Tokenization/IndexTokenizer.cs
@@ -10,9 +10,9 @@ using System.Text;
 namespace Lifti.Tokenization
 {
     /// <summary>
-    /// The default implementation of <see cref="ITokenizer"/> that just extracts tokens from plain text.
+    /// The default implementation of <see cref="IIndexTokenizer"/>.
     /// </summary>
-    public class Tokenizer : ITokenizer
+    public class IndexTokenizer : IIndexTokenizer
     {
         private readonly IInputPreprocessorPipeline inputPreprocessorPipeline;
         private readonly HashSet<char> additionalSplitChars;
@@ -20,10 +20,10 @@ namespace Lifti.Tokenization
         private readonly IStemmer? stemmer;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Tokenizer"/> class.
+        /// Initializes a new instance of the <see cref="IndexTokenizer"/> class.
         /// </summary>
         /// <param name="tokenizationOptions">The tokenization options for this instance.</param>
-        public Tokenizer(TokenizationOptions tokenizationOptions)
+        public IndexTokenizer(TokenizationOptions tokenizationOptions)
         {
             this.Options = tokenizationOptions ?? throw new ArgumentNullException(nameof(tokenizationOptions));
 
@@ -39,9 +39,9 @@ namespace Lifti.Tokenization
         }
 
         /// <summary>
-        /// Gets the default <see cref="ITokenizer"/> implementation, configured with <see cref="TokenizationOptions.Default"/>.
+        /// Gets the default <see cref="IIndexTokenizer"/> implementation, configured with <see cref="TokenizationOptions.Default"/>.
         /// </summary>
-        public static Tokenizer Default { get; } = new Tokenizer(TokenizationOptions.Default);
+        public static IndexTokenizer Default { get; } = new IndexTokenizer(TokenizationOptions.Default);
 
         /// <inheritdoc />
         public TokenizationOptions Options { get; }

--- a/src/Lifti.Core/Tokenization/Objects/AsyncStringArrayFieldReader.cs
+++ b/src/Lifti.Core/Tokenization/Objects/AsyncStringArrayFieldReader.cs
@@ -19,7 +19,7 @@ namespace Lifti.Tokenization.Objects
         internal AsyncStringArrayFieldReader(
             string name, 
             Func<TItem, Task<IEnumerable<string>>> reader, 
-            ITokenizer? tokenizer,
+            IIndexTokenizer? tokenizer,
             ITextExtractor? textExtractor)
             : base(name, tokenizer, textExtractor)
         {

--- a/src/Lifti.Core/Tokenization/Objects/AsyncStringFieldReader.cs
+++ b/src/Lifti.Core/Tokenization/Objects/AsyncStringFieldReader.cs
@@ -18,7 +18,7 @@ namespace Lifti.Tokenization.Objects
         internal AsyncStringFieldReader(
             string name,
             Func<TItem, Task<string>> reader,
-            ITokenizer? tokenizer,
+            IIndexTokenizer? tokenizer,
             ITextExtractor? textExtractor)
             : base(name, tokenizer, textExtractor)
         {

--- a/src/Lifti.Core/Tokenization/Objects/FieldReader.cs
+++ b/src/Lifti.Core/Tokenization/Objects/FieldReader.cs
@@ -8,7 +8,7 @@ namespace Lifti.Tokenization.Objects
     /// <inheritdoc />
     internal abstract class FieldReader<TItem> : IFieldReader<TItem>
     {
-        internal FieldReader(string name, ITokenizer? tokenizer, ITextExtractor? textExtractor)
+        internal FieldReader(string name, IIndexTokenizer? tokenizer, ITextExtractor? textExtractor)
         {
             this.Name = name ?? throw new ArgumentNullException(nameof(name));
             this.Tokenizer = tokenizer;
@@ -19,7 +19,7 @@ namespace Lifti.Tokenization.Objects
         public string Name { get; }
 
         /// <inheritdoc />
-        public ITokenizer? Tokenizer { get; }
+        public IIndexTokenizer? Tokenizer { get; }
 
         /// <inheritdoc />
         public ITextExtractor? TextExtractor { get; }

--- a/src/Lifti.Core/Tokenization/Objects/IFieldReader.cs
+++ b/src/Lifti.Core/Tokenization/Objects/IFieldReader.cs
@@ -15,9 +15,9 @@ namespace Lifti.Tokenization.Objects
         string Name { get; }
 
         /// <summary>
-        /// Gets the <see cref="ITokenizer"/> to be used for this field. If this is null then the default tokenizer for the index will be used.
+        /// Gets the <see cref="IIndexTokenizer"/> to be used for this field. If this is null then the default tokenizer for the index will be used.
         /// </summary>
-        ITokenizer? Tokenizer { get; }
+        IIndexTokenizer? Tokenizer { get; }
 
         /// <summary>
         /// Gets the <see cref="ITextExtractor"/> to be used for this field. If this is null then the default text extractor for the index will be used.

--- a/src/Lifti.Core/Tokenization/Objects/StringArrayFieldReader.cs
+++ b/src/Lifti.Core/Tokenization/Objects/StringArrayFieldReader.cs
@@ -19,7 +19,7 @@ namespace Lifti.Tokenization.Objects
         internal StringArrayFieldReader(
             string name,
             Func<TItem, IEnumerable<string>> reader,
-            ITokenizer? tokenizer,
+            IIndexTokenizer? tokenizer,
             ITextExtractor? textExtractor)
             : base(name, tokenizer, textExtractor)
         {

--- a/src/Lifti.Core/Tokenization/Objects/StringFieldReader.cs
+++ b/src/Lifti.Core/Tokenization/Objects/StringFieldReader.cs
@@ -18,7 +18,7 @@ namespace Lifti.Tokenization.Objects
         internal StringFieldReader(
             string name,
             Func<TItem, string> reader,
-            ITokenizer? tokenizer,
+            IIndexTokenizer? tokenizer,
             ITextExtractor? textExtractor)
             : base(name, tokenizer, textExtractor)
         {

--- a/src/Lifti.Core/TokenizationOptions.cs
+++ b/src/Lifti.Core/TokenizationOptions.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 namespace Lifti
 {
     /// <summary>
-    /// Options that can be provided to an <see cref="ITokenizer"/> to configure its behavior.
+    /// Options that can be provided to an <see cref="IIndexTokenizer"/> to configure its behavior.
     /// </summary>
     public class TokenizationOptions
     {

--- a/src/Lifti.Core/TokenizerBuilder.cs
+++ b/src/Lifti.Core/TokenizerBuilder.cs
@@ -4,28 +4,28 @@ using System;
 namespace Lifti
 {
     /// <summary>
-    /// A builder capable of creating an <see cref="ITokenizer"/> instance for use in an index.
+    /// A builder capable of creating an <see cref="IIndexTokenizer"/> instance for use in an index.
     /// </summary>
     public class TokenizerBuilder
     {
-        private static readonly Func<TokenizationOptions, ITokenizer> defaultTokenizerFactory = o => new Tokenizer(o);
+        private static readonly Func<TokenizationOptions, IIndexTokenizer> defaultTokenizerFactory = o => new IndexTokenizer(o);
 
         private bool splitOnPunctuation = true;
         private bool accentInsensitive = true;
         private bool caseInsensitive = true;
         private bool stemming = false;
         private char[]? additionalSplitCharacters;
-        private Func<TokenizationOptions, ITokenizer> factory = defaultTokenizerFactory;
+        private Func<TokenizationOptions, IIndexTokenizer> factory = defaultTokenizerFactory;
         private char[]? ignoreCharacters;
 
         /// <summary>
-        /// Configures a specific implementation of <see cref="ITokenizer"/> to be used. Use this
+        /// Configures a specific implementation of <see cref="IIndexTokenizer"/> to be used. Use this
         /// method if you need more control over the tokenization process.
         /// </summary>
         /// <param name="tokenizerFactory">
-        /// A delegate capable of creating the required <see cref="ITokenizer"/>.
+        /// A delegate capable of creating the required <see cref="IIndexTokenizer"/>.
         /// </param>
-        public TokenizerBuilder WithFactory(Func<TokenizationOptions, ITokenizer> tokenizerFactory)
+        public TokenizerBuilder WithFactory(Func<TokenizationOptions, IIndexTokenizer> tokenizerFactory)
         {
             this.factory = tokenizerFactory;
             return this;
@@ -102,9 +102,9 @@ namespace Lifti
         }
 
         /// <summary>
-        /// Builds an <see cref="ITokenizer"/> instance matching the current configuration.
+        /// Builds an <see cref="IIndexTokenizer"/> instance matching the current configuration.
         /// </summary>
-        public ITokenizer Build()
+        public IIndexTokenizer Build()
         {
             var options = new TokenizationOptions()
             {

--- a/src/Lifti.Core/TokenizerBuilderExtensions.cs
+++ b/src/Lifti.Core/TokenizerBuilderExtensions.cs
@@ -5,7 +5,7 @@ namespace Lifti
 {
     internal static class TokenizerBuilderExtensions
     {
-        public static ITokenizer? CreateTokenizer(this Func<TokenizerBuilder, TokenizerBuilder>? optionsBuilder)
+        public static IIndexTokenizer? CreateTokenizer(this Func<TokenizerBuilder, TokenizerBuilder>? optionsBuilder)
         {
             return optionsBuilder == null ?
                 null :

--- a/test/Lifti.Tests/FullTextIndexBuilderTests.cs
+++ b/test/Lifti.Tests/FullTextIndexBuilderTests.cs
@@ -54,8 +54,8 @@ namespace Lifti.Tests
 
             var index = this.sut.Build();
 
-            ((Tokenizer)index.FieldLookup.GetFieldInfo("Content").Tokenizer).Options.CaseInsensitive.Should().BeFalse();
-            ((Tokenizer)index.FieldLookup.GetFieldInfo("Title").Tokenizer).Options.CaseInsensitive.Should().BeTrue();
+            ((IndexTokenizer)index.FieldLookup.GetFieldInfo("Content").Tokenizer).Options.CaseInsensitive.Should().BeFalse();
+            ((IndexTokenizer)index.FieldLookup.GetFieldInfo("Title").Tokenizer).Options.CaseInsensitive.Should().BeTrue();
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace Lifti.Tests
 
             index.Search("test").Should().BeEmpty();
 
-            parser.Verify(p => p.Parse(It.IsAny<IIndexedFieldLookup>(), "test", It.IsAny<ITokenizer>()), Times.Once);
+            parser.Verify(p => p.Parse(It.IsAny<IIndexedFieldLookup>(), "test", It.IsAny<IIndexTokenizer>()), Times.Once);
         }
 
         [Fact]
@@ -268,7 +268,7 @@ namespace Lifti.Tests
         private Mock<IQueryParser> ConfigureQueryParserMock()
         {
             var parser = new Mock<IQueryParser>();
-            parser.Setup(p => p.Parse(It.IsAny<IIndexedFieldLookup>(), It.IsAny<string>(), It.IsAny<ITokenizer>()))
+            parser.Setup(p => p.Parse(It.IsAny<IIndexedFieldLookup>(), It.IsAny<string>(), It.IsAny<IIndexTokenizer>()))
                 .Returns(new Query(EmptyQueryPart.Instance));
 
             this.sut.WithQueryParser(parser.Object);

--- a/test/Lifti.Tests/FullTextIndexBuilderTests.cs
+++ b/test/Lifti.Tests/FullTextIndexBuilderTests.cs
@@ -64,7 +64,7 @@ namespace Lifti.Tests
             var passedOptions = BuildSutAndGetPassedOptions(o => o.WithFuzzySearchDefaults(10, 4));
 
             passedOptions.Should().NotBeNull();
-            passedOptions.FuzzySearchMaxEditDistance(1000).Should().Be(10);
+            passedOptions!.FuzzySearchMaxEditDistance(1000).Should().Be(10);
             passedOptions.FuzzySearchMaxSequentialEdits(1000).Should().Be(4);
         }
 
@@ -73,7 +73,7 @@ namespace Lifti.Tests
         {
             var passedOptions = BuildSutAndGetPassedOptions(o => o);
             passedOptions.Should().NotBeNull();
-            passedOptions.DefaultJoiningOperator.Should().Be(QueryTermJoinOperatorKind.And);
+            passedOptions!.DefaultJoiningOperator.Should().Be(QueryTermJoinOperatorKind.And);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace Lifti.Tests
         {
             var passedOptions = BuildSutAndGetPassedOptions(o => o.WithDefaultJoiningOperator(QueryTermJoinOperatorKind.Or));
             passedOptions.Should().NotBeNull();
-            passedOptions.DefaultJoiningOperator.Should().Be(QueryTermJoinOperatorKind.Or);
+            passedOptions!.DefaultJoiningOperator.Should().Be(QueryTermJoinOperatorKind.Or);
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace Lifti.Tests
             index.Search("test");
 
             passedOptions.Should().NotBeNull();
-            passedOptions.FuzzySearchMaxEditDistance(1000).Should().Be(100);
+            passedOptions!.FuzzySearchMaxEditDistance(1000).Should().Be(100);
             passedOptions.FuzzySearchMaxSequentialEdits(1000).Should().Be(10);
         }
 
@@ -120,13 +120,13 @@ namespace Lifti.Tests
 
             index.Search("test").Should().BeEmpty();
 
-            parser.Verify(p => p.Parse(It.IsAny<IIndexedFieldLookup>(), "test", It.IsAny<IIndexTokenizer>()), Times.Once);
+            parser.Verify(p => p.Parse(It.IsAny<IIndexedFieldLookup>(), "test", index), Times.Once);
         }
 
         [Fact]
         public void WithQueryParserOptions_ShouldPassOptionsToQueryParser()
         {
-            QueryParserOptions providedOptions = null;
+            QueryParserOptions? providedOptions = null;
 
             this.sut.WithQueryParser(o => o
                 .AssumeFuzzySearchTerms()
@@ -205,8 +205,8 @@ namespace Lifti.Tests
 
             await index.AddAsync(9, "Test");
 
-            action1.Should().BeEquivalentTo("1");
-            action2.Should().BeEquivalentTo(1);
+            action1.Should().BeEquivalentTo(new[] { "1" });
+            action2.Should().BeEquivalentTo(new[] { 1 });
         }
 
         [Fact]
@@ -250,7 +250,7 @@ namespace Lifti.Tests
             results[0].Key.Should().Be(12);
         }
 
-        private QueryParserOptions BuildSutAndGetPassedOptions(Func<QueryParserBuilder, QueryParserBuilder> optionsBuilder)
+        private QueryParserOptions? BuildSutAndGetPassedOptions(Func<QueryParserBuilder, QueryParserBuilder> optionsBuilder)
         {
             QueryParserOptions? passedOptions = null;
 
@@ -268,7 +268,7 @@ namespace Lifti.Tests
         private Mock<IQueryParser> ConfigureQueryParserMock()
         {
             var parser = new Mock<IQueryParser>();
-            parser.Setup(p => p.Parse(It.IsAny<IIndexedFieldLookup>(), It.IsAny<string>(), It.IsAny<IIndexTokenizer>()))
+            parser.Setup(p => p.Parse(It.IsAny<IIndexedFieldLookup>(), It.IsAny<string>(), It.IsAny<IIndexTokenizerProvider>()))
                 .Returns(new Query(EmptyQueryPart.Instance));
 
             this.sut.WithQueryParser(parser.Object);

--- a/test/Lifti.Tests/FullTextIndexTests.cs
+++ b/test/Lifti.Tests/FullTextIndexTests.cs
@@ -60,10 +60,12 @@ namespace Lifti.Tests
             var results = this.index.Search("test");
             results.Should().HaveCount(1);
             results.Single().FieldMatches.Single().Locations.Should().BeEquivalentTo(
-                new TokenLocation(0, 0, 4),
-                new TokenLocation(1, 5, 4),
-                new TokenLocation(2, 11, 4)
-            );
+                new[]
+                {
+                    new TokenLocation(0, 0, 4),
+                    new TokenLocation(1, 5, 4),
+                    new TokenLocation(2, 11, 4)
+                });
         }
 
         [Fact]

--- a/test/Lifti.Tests/IdPoolTests.cs
+++ b/test/Lifti.Tests/IdPoolTests.cs
@@ -84,12 +84,14 @@ namespace Lifti.Tests
             this.sut.Add("7", DocumentStatistics((7, 7)));
 
             this.sut.GetIndexedItems().Should().BeEquivalentTo(
-                new ItemMetadata<string>(0, "1", item1DocumentStatistics),
-                new ItemMetadata<string>(1, "2", item2DocumentStatistics),
-                new ItemMetadata<string>(9, "9", DocumentStatistics((9, 9))),
-                new ItemMetadata<string>(10, "10", DocumentStatistics((10, 10))),
-                new ItemMetadata<string>(11, "7", DocumentStatistics((7, 7)))
-            );
+                new[]
+                {
+                    new ItemMetadata<string>(0, "1", item1DocumentStatistics),
+                    new ItemMetadata<string>(1, "2", item2DocumentStatistics),
+                    new ItemMetadata<string>(9, "9", DocumentStatistics((9, 9))),
+                    new ItemMetadata<string>(10, "10", DocumentStatistics((10, 10))),
+                    new ItemMetadata<string>(11, "7", DocumentStatistics((7, 7)))
+                });
         }
 
         [Fact]
@@ -102,9 +104,11 @@ namespace Lifti.Tests
         public void GetIndexedItems_ShouldReturnMetadataForAllItemsInTheIndex()
         {
             this.sut.GetIndexedItems().Should().BeEquivalentTo(
-                new ItemMetadata<string>(0, "1", item1DocumentStatistics),
-                new ItemMetadata<string>(1, "2", item2DocumentStatistics)
-            );
+                new[]
+                {
+                    new ItemMetadata<string>(0, "1", item1DocumentStatistics),
+                    new ItemMetadata<string>(1, "2", item2DocumentStatistics)
+                });
         }
 
         [Fact]

--- a/test/Lifti.Tests/IndexedFieldLookupTests.cs
+++ b/test/Lifti.Tests/IndexedFieldLookupTests.cs
@@ -25,7 +25,7 @@ namespace Lifti.Tests
             this.sut = new IndexedFieldLookup(
                 itemConfig.GetConfiguredFields(), 
                 new PlainTextExtractor(), 
-                Tokenizer.Default);
+                IndexTokenizer.Default);
         }
 
         [Fact]
@@ -39,8 +39,8 @@ namespace Lifti.Tests
         [Fact]
         public void GettingTokenizationOptionsShouldReturnCorrectlyConstructedInstances()
         {
-            ((Tokenizer)this.sut.GetFieldInfo("FieldX").Tokenizer).Options.Stemming.Should().BeTrue();
-            ((Tokenizer)this.sut.GetFieldInfo("FieldY").Tokenizer).Options.Stemming.Should().BeFalse();
+            ((IndexTokenizer)this.sut.GetFieldInfo("FieldX").Tokenizer).Options.Stemming.Should().BeTrue();
+            ((IndexTokenizer)this.sut.GetFieldInfo("FieldY").Tokenizer).Options.Stemming.Should().BeFalse();
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace Lifti.Tests
 
             IObjectTokenization config = itemConfigBuilder.Build();
 
-            Assert.Throws<LiftiException>(() => new IndexedFieldLookup(config.GetConfiguredFields(), new PlainTextExtractor(), Tokenizer.Default))
+            Assert.Throws<LiftiException>(() => new IndexedFieldLookup(config.GetConfiguredFields(), new PlainTextExtractor(), IndexTokenizer.Default))
                 .Message.Should().Be("Only 255 distinct fields can currently be indexed");
         }
 
@@ -84,7 +84,7 @@ namespace Lifti.Tests
                 .WithKey(i => i)
                 .Build();
 
-            Assert.Throws<LiftiException>(() => new IndexedFieldLookup(config.GetConfiguredFields(), new PlainTextExtractor(), Tokenizer.Default))
+            Assert.Throws<LiftiException>(() => new IndexedFieldLookup(config.GetConfiguredFields(), new PlainTextExtractor(), IndexTokenizer.Default))
                 .Message.Should().Be("Duplicate field name used: Field1. Field names must be unique across all item types registered with an index.");
         }
     }

--- a/test/Lifti.Tests/Lifti.Tests.csproj
+++ b/test/Lifti.Tests/Lifti.Tests.csproj
@@ -5,6 +5,7 @@
 
     <IsPackable>false</IsPackable>
     <LangVersion>10.0</LangVersion>
+	  <Nullable>enable</Nullable>
   </PropertyGroup>
 	
   <ItemGroup>
@@ -21,11 +22,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.10.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.4" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+    <PackageReference Include="FluentAssertions" Version="6.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/test/Lifti.Tests/Querying/CompositePositionalIntersectMergerTests.cs
+++ b/test/Lifti.Tests/Querying/CompositePositionalIntersectMergerTests.cs
@@ -45,9 +45,10 @@ namespace Lifti.Tests.Querying
             var right = IntermediateQueryResult(ScoredToken(7, ScoredFieldMatch(1D, 1, 35)));
             var result = CompositePositionalIntersectMerger.Apply(left, right, 0, 5);
 
-            result.Should().BeEquivalentTo(
+            result.Should().BeEquivalentTo(new[]
+            {
                 ScoredToken(7,ScoredFieldMatch(2D, 1, (30, 35)))
-            );
+            });
         }
 
         [Fact]
@@ -55,11 +56,13 @@ namespace Lifti.Tests.Querying
         {
             var result = CompositePositionalIntersectMerger.Apply(exactMatchLeft, exactMatchRight, 0, 5);
 
-            result.Should().BeEquivalentTo(
+            result.Should().BeEquivalentTo(new[]
+            {
                 ScoredToken(
                     7,
                     ScoredFieldMatch(2D, 1, (30, 35)),
-                    ScoredFieldMatch(4D, 2, (5, 10))));
+                    ScoredFieldMatch(4D, 2, (5, 10)))
+            });
         }
 
         [Fact]

--- a/test/Lifti.Tests/Querying/FakeIndexTokenizer.cs
+++ b/test/Lifti.Tests/Querying/FakeIndexTokenizer.cs
@@ -6,16 +6,17 @@ using System.Linq;
 
 namespace Lifti.Tests.Querying
 {
-    public class FakeTokenizer : IIndexTokenizer
+    public class FakeIndexTokenizer : IIndexTokenizer
     {
         private readonly bool normalizeToUppercase;
 
-        public FakeTokenizer(bool normalizeToUppercase = false)
+        public FakeIndexTokenizer(bool normalizeToUppercase = false)
+            : this(new TokenizationOptions())
         {
             this.normalizeToUppercase = normalizeToUppercase;
         }
 
-        public FakeTokenizer(TokenizationOptions options)
+        public FakeIndexTokenizer(TokenizationOptions options)
         {
             this.Options = options;
         }

--- a/test/Lifti.Tests/Querying/FakeIndexTokenizerProvider.cs
+++ b/test/Lifti.Tests/Querying/FakeIndexTokenizerProvider.cs
@@ -1,0 +1,26 @@
+﻿using Lifti.Tokenization;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Lifti.Tests.Querying
+{
+    public class FakeIndexTokenizerProvider : IIndexTokenizerProvider
+    {
+        private readonly Dictionary<string, IIndexTokenizer> fieldIndexTokenizers;
+
+        public FakeIndexTokenizerProvider()
+            : this(new FakeIndexTokenizer())
+        {
+        }
+
+        public FakeIndexTokenizerProvider(IIndexTokenizer defaultIndexTokenizer, params (string, IIndexTokenizer)[] fieldIndexTokenizers)
+        {
+            this.DefaultTokenizer = defaultIndexTokenizer;
+            this.fieldIndexTokenizers = fieldIndexTokenizers.ToDictionary(x => x.Item1, x => x.Item2);
+        }
+
+        public IIndexTokenizer this[string fieldName] => this.fieldIndexTokenizers[fieldName];
+
+        public IIndexTokenizer DefaultTokenizer { get; private set; }
+    }
+}

--- a/test/Lifti.Tests/Querying/FakeTokenizer.cs
+++ b/test/Lifti.Tests/Querying/FakeTokenizer.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Lifti.Tests.Querying
 {
-    public class FakeTokenizer : ITokenizer
+    public class FakeTokenizer : IIndexTokenizer
     {
         private readonly bool normalizeToUppercase;
 

--- a/test/Lifti.Tests/Querying/IndexNavigatorTests.cs
+++ b/test/Lifti.Tests/Querying/IndexNavigatorTests.cs
@@ -8,8 +8,8 @@ namespace Lifti.Tests.Querying
 {
     public class IndexNavigatorTests : QueryTestBase, IAsyncLifetime
     {
-        private FullTextIndex<string> index;
-        private IIndexNavigator sut;
+        private FullTextIndex<string> index = null!;
+        private IIndexNavigator sut = null!;
 
         public async Task InitializeAsync()
         {
@@ -70,7 +70,7 @@ namespace Lifti.Tests.Querying
                 },
                 o => o.ComparingByMembers<ScoredToken>()
                       .ComparingByMembers<ScoredFieldMatch>()
-                      .Excluding(i => i.SelectedMemberPath.EndsWith("Score")));
+                      .Excluding(i => i.Path.EndsWith("Score")));
         }
 
         [Theory]
@@ -172,7 +172,7 @@ namespace Lifti.Tests.Querying
                 expectedTokens,
                 o => o.ComparingByMembers<ScoredToken>()
                       .ComparingByMembers<ScoredFieldMatch>()
-                      .Excluding(i => i.SelectedMemberPath.EndsWith("Score")));
+                      .Excluding(i => i.Path.EndsWith("Score")));
         }
 
         [Theory]

--- a/test/Lifti.Tests/Querying/IntersectMergerTests.cs
+++ b/test/Lifti.Tests/Querying/IntersectMergerTests.cs
@@ -13,12 +13,13 @@ namespace Lifti.Tests.Querying
             var right = IntermediateQueryResult(ScoredToken(7, ScoredFieldMatch(3D, 1, 35, 37, 42)));
             var result = IntersectMerger.Apply(left, right);
 
-            result.Should().BeEquivalentTo(new[]
-            {
-                ScoredToken(
-                    7,
-                    ScoredFieldMatch(4D, 1, 30, 35, 37, 41, 42))
-            });
+            result.Should().BeEquivalentTo(
+                new[]
+                {
+                    ScoredToken(
+                        7,
+                        ScoredFieldMatch(4D, 1, 30, 35, 37, 41, 42))
+                });
         }
 
         [Fact]
@@ -36,8 +37,11 @@ namespace Lifti.Tests.Querying
             var rightLeftResult = IntersectMerger.Apply(right, left);
 
             leftRightResult.Should().BeEquivalentTo(
-                ScoredToken(6, ScoredFieldMatch(6D, 1, 20, 60)),
-                ScoredToken(9, ScoredFieldMatch(8D, 1, 10, 80)));
+                new[]
+                {
+                    ScoredToken(6, ScoredFieldMatch(6D, 1, 20, 60)),
+                    ScoredToken(9, ScoredFieldMatch(8D, 1, 10, 80))
+                });
 
             leftRightResult.Should().BeEquivalentTo(rightLeftResult);
         }

--- a/test/Lifti.Tests/Querying/QueryParserTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParserTests.cs
@@ -13,6 +13,8 @@ namespace Lifti.Tests.Querying
         private const byte TestFieldId = 9;
         private const byte OtherFieldId = 11;
         private readonly Mock<IIndexedFieldLookup> fieldLookupMock;
+        private readonly FakeIndexTokenizer field1Tokenizer;
+        private readonly FakeIndexTokenizer field2Tokenizer;
 
         public QueryParserTests()
         {
@@ -20,10 +22,11 @@ namespace Lifti.Tests.Querying
             var testFieldId = TestFieldId;
             var otherFieldId = OtherFieldId;
 
-            var tokenizer = new FakeTokenizer();
+            this.field1Tokenizer = new FakeIndexTokenizer();
+            this.field2Tokenizer = new FakeIndexTokenizer();
             var textExtractor = new PlainTextExtractor();
-            this.fieldLookupMock.Setup(l => l.GetFieldInfo("testfield")).Returns(new IndexedFieldDetails(testFieldId, textExtractor, tokenizer));
-            this.fieldLookupMock.Setup(l => l.GetFieldInfo("otherfield")).Returns(new IndexedFieldDetails(otherFieldId, textExtractor, tokenizer));
+            this.fieldLookupMock.Setup(l => l.GetFieldInfo("testfield")).Returns(new IndexedFieldDetails(testFieldId, textExtractor, this.field1Tokenizer));
+            this.fieldLookupMock.Setup(l => l.GetFieldInfo("otherfield")).Returns(new IndexedFieldDetails(otherFieldId, textExtractor, this.field2Tokenizer));
         }
 
         [Fact]
@@ -143,7 +146,7 @@ namespace Lifti.Tests.Querying
 
             VerifyResult(result, expectedQuery);
         }
-
+        
         [Fact]
         public void ParsingBracketedAndExpressions_ShouldReturnBracketedQueryPartContainer()
         {
@@ -332,7 +335,13 @@ namespace Lifti.Tests.Querying
             options.DefaultJoiningOperator = defaultJoinOperator;
 
             var parser = new QueryParser(options);
-            return parser.Parse(this.fieldLookupMock.Object, text, new FakeTokenizer());
+            return parser.Parse(
+                this.fieldLookupMock.Object, 
+                text, 
+                new FakeIndexTokenizerProvider(
+                    new FakeIndexTokenizer(),
+                    ("testfield", this.field1Tokenizer),
+                    ("otherfield", this.field2Tokenizer)));
         }
     }
 }

--- a/test/Lifti.Tests/Querying/QueryParts/FieldFilterQueryOperatorTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/FieldFilterQueryOperatorTests.cs
@@ -18,9 +18,11 @@ namespace Lifti.Tests.Querying.QueryParts
             var results = sut.Evaluate(() => navigator, QueryContext.Empty);
 
             results.Matches.Should().BeEquivalentTo(
+                new[]
+                {
                     ScoredToken(2, ScoredFieldMatch(2D, 4, 1)),
                     ScoredToken(4, ScoredFieldMatch(4D, 4, 44, 99))
-                );
+                });
         }
     }
 }

--- a/test/Lifti.Tests/Querying/QueryParts/FuzzyWordQueryPartTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/FuzzyWordQueryPartTests.cs
@@ -19,7 +19,7 @@ namespace Lifti.Tests.Querying.QueryParts
             "Odius ogres obey Mobius"
         };
 
-        public FullTextIndex<int> Index { get; private set; }
+        public FullTextIndex<int> Index { get; private set; } = null!;
 
         public Task DisposeAsync()
         {
@@ -129,7 +129,7 @@ namespace Lifti.Tests.Querying.QueryParts
 
             var results = index.Search(query).ToList();
 
-            results.Select(x => x.Key).Should().BeEquivalentTo(1, 3);
+            results.Select(x => x.Key).Should().BeEquivalentTo(new[] { 1, 3 });
         }
 
         [Theory]

--- a/test/Lifti.Tests/Querying/QueryParts/NearQueryOperatorTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/NearQueryOperatorTests.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using Lifti.Querying;
 using Lifti.Querying.QueryParts;
 using Xunit;
 
@@ -26,14 +25,16 @@ namespace Lifti.Tests.Querying.QueryParts
             // Item 8 matches:
             // Field 1: (101, 106)
             // Field 2: (8, 3) (104, 105)
-            results.Matches.Should().BeEquivalentTo(
+            results.Matches.Should().BeEquivalentTo(new[]
+            {
                 ScoredToken(
                     7,
                     ScoredFieldMatch(4D, 1, CompositeMatch(8, 6), CompositeMatch(100, 102))),
                 ScoredToken(
                     8,
                     ScoredFieldMatch(6D, 1, CompositeMatch(101, 106)),
-                    ScoredFieldMatch(13D, 2, CompositeMatch(8, 3), CompositeMatch(104, 105))));
+                    ScoredFieldMatch(13D, 2, CompositeMatch(8, 3), CompositeMatch(104, 105)))
+            });
         }
     }
 }

--- a/test/Lifti.Tests/Querying/QueryParts/PrecedingNearQueryOperatorTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/PrecedingNearQueryOperatorTests.cs
@@ -28,13 +28,16 @@ namespace Lifti.Tests.Querying.QueryParts
             // Field 1: (101, 106)
             // Field 2: (104, 105)
             results.Matches.Should().BeEquivalentTo(
-                ScoredToken(
-                    7,
-                    ScoredFieldMatch(4D, 1, CompositeMatch(100, 102))),
-                ScoredToken(
-                    8,
-                    ScoredFieldMatch(6D, 1, CompositeMatch(101, 106)),
-                    ScoredFieldMatch(13D, 2, CompositeMatch(104, 105))));
+                new[]
+                {
+                    ScoredToken(
+                        7,
+                        ScoredFieldMatch(4D, 1, CompositeMatch(100, 102))),
+                    ScoredToken(
+                        8,
+                        ScoredFieldMatch(6D, 1, CompositeMatch(101, 106)),
+                        ScoredFieldMatch(13D, 2, CompositeMatch(104, 105)))
+                });
         }
 
         [Fact]
@@ -50,8 +53,11 @@ namespace Lifti.Tests.Querying.QueryParts
 
             var fieldMatch = result.FieldMatches.Single();
             fieldMatch.Locations.Should().BeEquivalentTo(
-                new TokenLocation(11, 67, 8),
-                new TokenLocation(12, 76, 7));
+                new[]
+                {
+                    new TokenLocation(11, 67, 8),
+                    new TokenLocation(12, 76, 7)
+                });
         }
 
         protected static async Task<IFullTextIndex<int>> CreateTestIndexAsync()

--- a/test/Lifti.Tests/Querying/QueryParts/PrecedingQueryOperatorTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/PrecedingQueryOperatorTests.cs
@@ -27,13 +27,16 @@ namespace Lifti.Tests.Querying.QueryParts
             // Field 1: 11, 106, 101
             // Field 2: 8, 105, 104
             results.Matches.Should().BeEquivalentTo(
-                ScoredToken(
-                    7,
-                    ScoredFieldMatch(4D, 1, TokenMatch(8), TokenMatch(14), TokenMatch(20), TokenMatch(100), TokenMatch(102))),
-                ScoredToken(
-                    8,
-                    ScoredFieldMatch(6D, 1, TokenMatch(11), TokenMatch(101), TokenMatch(106)),
-                    ScoredFieldMatch(13D, 2, TokenMatch(8), TokenMatch(104), TokenMatch(105))));
+                new[]
+                {
+                    ScoredToken(
+                        7,
+                        ScoredFieldMatch(4D, 1, TokenMatch(8), TokenMatch(14), TokenMatch(20), TokenMatch(100), TokenMatch(102))),
+                    ScoredToken(
+                        8,
+                        ScoredFieldMatch(6D, 1, TokenMatch(11), TokenMatch(101), TokenMatch(106)),
+                        ScoredFieldMatch(13D, 2, TokenMatch(8), TokenMatch(104), TokenMatch(105)))
+                });
         }
     }
 }

--- a/test/Lifti.Tests/Querying/QueryParts/WildcardQueryPartTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/WildcardQueryPartTests.cs
@@ -9,10 +9,20 @@ namespace Lifti.Tests.Querying.QueryParts
 {
     public class WildcardQueryPartTests : IAsyncLifetime
     {
-        private FullTextIndex<int> index;
+        private FullTextIndex<int> index = null!;
 
-        public WildcardQueryPartTests()
+        public Task DisposeAsync()
         {
+            return Task.CompletedTask;
+        }
+
+        public async Task InitializeAsync()
+        {
+            this.index = new FullTextIndexBuilder<int>()
+                .Build();
+
+            await this.index.AddAsync(1, "Apparently this also applies");
+            await this.index.AddAsync(2, "Angry alternatives to apples, thus");
         }
 
         [Fact]
@@ -247,21 +257,7 @@ namespace Lifti.Tests.Querying.QueryParts
 
             var results = index.Search(query).ToList();
 
-            results.Select(x => x.Key).Should().BeEquivalentTo(1, 3);
-        }
-
-        public Task DisposeAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        public async Task InitializeAsync()
-        {
-            this.index = new FullTextIndexBuilder<int>()
-                .Build();
-
-            await this.index.AddAsync(1, "Apparently this also applies");
-            await this.index.AddAsync(2, "Angry alternatives to apples, thus");
+            results.Select(x => x.Key).Should().BeEquivalentTo(new[] { 1, 3 });
         }
 
         private record TestObject(int Id, string Title, string Content);

--- a/test/Lifti.Tests/Querying/QueryTokenizerTests.cs
+++ b/test/Lifti.Tests/Querying/QueryTokenizerTests.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using Lifti.Querying;
+using Lifti.Tokenization;
 using System;
 using System.Linq;
 using Xunit;
@@ -9,93 +10,154 @@ namespace Lifti.Tests.Querying
     public class QueryTokenizerTests
     {
         private readonly QueryTokenizer sut;
-        private readonly FakeTokenizer tokenizer;
+        private readonly IIndexTokenizer defaultIndexTokenizer;
+        private readonly IIndexTokenizer fieldIndexTokenizer;
+        private readonly IIndexTokenizerProvider tokenizerProvider;
 
         public QueryTokenizerTests()
         {
             this.sut = new QueryTokenizer();
 
-            this.tokenizer = new FakeTokenizer();
+            this.defaultIndexTokenizer = new FakeIndexTokenizer();
+            this.fieldIndexTokenizer = new FakeIndexTokenizer(true);
+            this.tokenizerProvider = new FakeIndexTokenizerProvider(this.defaultIndexTokenizer, ("test", this.fieldIndexTokenizer));
         }
 
         [Fact]
         public void EmptyStringYieldsNoResults()
         {
-            this.sut.ParseQueryTokens(string.Empty, this.tokenizer).Should().BeEmpty();
+            this.sut.ParseQueryTokens(string.Empty, this.tokenizerProvider).Should().BeEmpty();
         }
 
         [Fact]
         public void NullStringThrowsException()
         {
-            Assert.Throws<ArgumentNullException>(() => this.sut.ParseQueryTokens(null, this.tokenizer).ToArray());
+            Assert.Throws<ArgumentNullException>(() => this.sut.ParseQueryTokens(null!, this.tokenizerProvider).ToArray());
         }
 
         [Fact]
         public void SingleWordYieldsOneResult()
         {
-            this.sut.ParseQueryTokens("Testing", this.tokenizer).Should().BeEquivalentTo(
-                QueryToken.ForText("Testing"));
+            this.sut.ParseQueryTokens("Testing", this.tokenizerProvider).Should().BeEquivalentTo(new[]
+            {
+                QueryToken.ForText("Testing", this.defaultIndexTokenizer)
+            });
         }
 
         [Fact]
         public void FuzzySearchTermsYieldedCorrectly()
         {
-            this.sut.ParseQueryTokens("?Testing ?1,2?Test ?,?Test", this.tokenizer).Should().BeEquivalentTo(
-                QueryToken.ForText("?Testing"),
-                QueryToken.ForText("?1,2?Test"),
-                QueryToken.ForText("?,?Test"));
+            this.sut.ParseQueryTokens("?Testing ?1,2?Test ?,?Test", this.tokenizerProvider).Should().BeEquivalentTo(new[]
+            {
+                QueryToken.ForText("?Testing", this.defaultIndexTokenizer),
+                QueryToken.ForText("?1,2?Test", this.defaultIndexTokenizer),
+                QueryToken.ForText("?,?Test", this.defaultIndexTokenizer)
+            });
+        }
+
+        [InlineData("(Testing & test))")]
+        [InlineData(")")]
+        [InlineData("((test) & test) & test)")]
+        [Theory]
+        public void UnexpectedCloseBracketShouldThrowException(string query)
+        {
+            Assert.Throws<QueryParserException>(() => this.sut.ParseQueryTokens(query, this.tokenizerProvider).ToList())
+                .Message.Should().Be("Unexpected close bracket encountered in query");
         }
 
         [Fact]
         public void FuzzySearchTermsSeparatedByCommasYieldedCorrectly()
         {
-            this.sut.ParseQueryTokens("?Testing,?Test2", this.tokenizer).Should().BeEquivalentTo(
-                QueryToken.ForText("?Testing"),
-                QueryToken.ForText("?Test2"));
+            this.sut.ParseQueryTokens("?Testing,?Test2", this.tokenizerProvider).Should().BeEquivalentTo(
+                new[] {
+                QueryToken.ForText("?Testing", this.defaultIndexTokenizer),
+                QueryToken.ForText("?Test2", this.defaultIndexTokenizer)
+                });
         }
 
         [Fact]
         public void EmptyFuzzySearchTermsShouldYieldNoTokens()
         {
-            this.sut.ParseQueryTokens("? ?1,2? ?,? ?? ???", this.tokenizer).Should().BeEmpty();
+            this.sut.ParseQueryTokens("? ?1,2? ?,? ?? ???", this.tokenizerProvider).Should().BeEmpty();
         }
 
         [Fact]
         public void SingleWordWithSpacePaddingYieldsOneResult()
         {
-            this.sut.ParseQueryTokens("  \t  Testing   \t ", this.tokenizer).Should().BeEquivalentTo(
-                QueryToken.ForText("Testing"));
+            this.sut.ParseQueryTokens("  \t  Testing   \t ", this.tokenizerProvider).Should().BeEquivalentTo(new[]
+            {
+                QueryToken.ForText("Testing", this.defaultIndexTokenizer)
+            });
         }
 
         [Fact]
         public void CompositeStringYieldsOneResult()
         {
-            this.sut.ParseQueryTokens("\"Jack be quick\"", this.tokenizer).Should().BeEquivalentTo(
+            this.sut.ParseQueryTokens("\"Jack be quick\"", this.tokenizerProvider).Should().BeEquivalentTo(new[]
+            {
                 QueryToken.ForOperator(QueryTokenType.BeginAdjacentTextOperator),
-                QueryToken.ForText("Jack"),
-                QueryToken.ForText("be"),
-                QueryToken.ForText("quick"),
-                QueryToken.ForOperator(QueryTokenType.EndAdjacentTextOperator));
+                QueryToken.ForText("Jack", this.defaultIndexTokenizer),
+                QueryToken.ForText("be", this.defaultIndexTokenizer),
+                QueryToken.ForText("quick", this.defaultIndexTokenizer),
+                QueryToken.ForOperator(QueryTokenType.EndAdjacentTextOperator)
+            });
         }
 
         [Fact]
         public void TwoCompositeStringsYieldsSixResults()
         {
-            this.sut.ParseQueryTokens(@"""First string"" ""Second string""", this.tokenizer).Should().BeEquivalentTo(
+            this.sut.ParseQueryTokens(@"""First string"" ""Second string""", this.tokenizerProvider).Should().BeEquivalentTo(new[]
+            {
                 QueryToken.ForOperator(QueryTokenType.BeginAdjacentTextOperator),
-                QueryToken.ForText("First"),
-                QueryToken.ForText("string"),
+                QueryToken.ForText("First", this.defaultIndexTokenizer),
+                QueryToken.ForText("string", this.defaultIndexTokenizer),
                 QueryToken.ForOperator(QueryTokenType.EndAdjacentTextOperator),
                 QueryToken.ForOperator(QueryTokenType.BeginAdjacentTextOperator),
-                QueryToken.ForText("Second"),
-                QueryToken.ForText("string"),
-                QueryToken.ForOperator(QueryTokenType.EndAdjacentTextOperator));
+                QueryToken.ForText("Second", this.defaultIndexTokenizer),
+                QueryToken.ForText("string", this.defaultIndexTokenizer),
+                QueryToken.ForOperator(QueryTokenType.EndAdjacentTextOperator)
+            });
+        }
+
+        [Fact]
+        public void TextTokensForField_ShouldHaveCorrectTokenizerAssociatedToThem()
+        {
+            this.sut.ParseQueryTokens(@"test=""test string"" notfield test=sim%le nofield test=(yes* (""field too"") ?stillfield) notinfieldagain", this.tokenizerProvider).Should().BeEquivalentTo(new[]
+                {
+                    QueryToken.ForFieldFilter("test"),
+                    QueryToken.ForOperator(QueryTokenType.BeginAdjacentTextOperator),
+                    QueryToken.ForText("test", this.fieldIndexTokenizer),
+                    QueryToken.ForText("string", this.fieldIndexTokenizer),
+                    QueryToken.ForOperator(QueryTokenType.EndAdjacentTextOperator),
+                    QueryToken.ForText("notfield", this.defaultIndexTokenizer),
+                    QueryToken.ForFieldFilter("test"),
+                    QueryToken.ForText("sim%le", this.fieldIndexTokenizer),
+                    QueryToken.ForText("nofield", this.defaultIndexTokenizer),
+                    QueryToken.ForFieldFilter("test"),
+                    QueryToken.ForOperator(QueryTokenType.OpenBracket),
+                    QueryToken.ForText("yes*", this.fieldIndexTokenizer),
+                    QueryToken.ForOperator(QueryTokenType.OpenBracket),
+                    QueryToken.ForOperator(QueryTokenType.BeginAdjacentTextOperator),
+                    QueryToken.ForText("field", this.fieldIndexTokenizer),
+                    QueryToken.ForText("too", this.fieldIndexTokenizer),
+                    QueryToken.ForOperator(QueryTokenType.BeginAdjacentTextOperator),
+                    QueryToken.ForOperator(QueryTokenType.CloseBracket),
+                    QueryToken.ForText("?stillfield", this.fieldIndexTokenizer),
+                    QueryToken.ForOperator(QueryTokenType.CloseBracket),
+                    QueryToken.ForText("notinfieldagain", this.defaultIndexTokenizer)
+                },
+                options => options
+                    .WithStrictOrdering()
+                    .Using<QueryToken>(
+                    x => x.Subject.IndexTokenizer.Should().BeSameAs(x.Expectation.IndexTokenizer))
+                .WhenTypeIs<QueryToken>());
         }
 
         [Fact]
         public void OperatorTokensAreParsedCorrectly()
         {
-            this.sut.ParseQueryTokens(@"& ( | ) ~> ~2> > ~ ~2 test=", this.tokenizer).Should().BeEquivalentTo(
+            this.sut.ParseQueryTokens(@"& ( | ) ~> ~2> > ~ ~2 test=", this.tokenizerProvider).Should().BeEquivalentTo(new[]
+            {
                 QueryToken.ForOperator(QueryTokenType.AndOperator),
                 QueryToken.ForOperator(QueryTokenType.OpenBracket),
                 QueryToken.ForOperator(QueryTokenType.OrOperator),
@@ -105,13 +167,14 @@ namespace Lifti.Tests.Querying
                 QueryToken.ForOperator(QueryTokenType.PrecedingOperator),
                 QueryToken.ForOperatorWithTolerance(QueryTokenType.NearOperator, 5),
                 QueryToken.ForOperatorWithTolerance(QueryTokenType.NearOperator, 2),
-                QueryToken.ForFieldFilter("test"));
+                QueryToken.ForFieldFilter("test")
+            });
         }
 
         [Fact]
         public void UnknownOperatorTokensRaiseExceptions()
         {
-            Assert.Throws<QueryParserException>(() => this.sut.ParseQueryTokens(@"test =", this.tokenizer).ToArray())
+            Assert.Throws<QueryParserException>(() => this.sut.ParseQueryTokens(@"test =", this.tokenizerProvider).ToArray())
                 .Message.Should().Be("An unexpected operator was encountered: =");
         }
     }

--- a/test/Lifti.Tests/Querying/SimpleQueryParserTests.cs
+++ b/test/Lifti.Tests/Querying/SimpleQueryParserTests.cs
@@ -12,7 +12,7 @@ namespace Lifti.Tests.Querying
         [Fact]
         public void PunctuationInTerms_ShouldBeStripped()
         {
-            var result = this.Parse("wordone,wordtwo?! (wordthree)");
+            var result = Parse("wordone,wordtwo?! (wordthree)");
             var expectedQuery = AndQueryOperator.CombineAll(new[] { new ExactWordQueryPart("WORDONE"), new ExactWordQueryPart("WORDTWO"), new ExactWordQueryPart("WORDTHREE") });
             VerifyResult(result, expectedQuery);
         }
@@ -20,7 +20,7 @@ namespace Lifti.Tests.Querying
         [Fact]
         public void ParsingTwoWordsWithNoOperator_WithAndOperatorAsDefault_ShouldComposeWithAndOperator()
         {
-            var result = this.Parse("wordone wordtwo");
+            var result = Parse("wordone wordtwo");
             var expectedQuery = new AndQueryOperator(new ExactWordQueryPart("WORDONE"), new ExactWordQueryPart("WORDTWO"));
             VerifyResult(result, expectedQuery);
         }
@@ -28,7 +28,7 @@ namespace Lifti.Tests.Querying
         [Fact]
         public void ParsingTwoWordsWithNoOperator_WithOrOperatorAsDefault_ShouldComposeWithOrOperator()
         {
-            var result = this.Parse("wordone wordtwo", defaultJoinOperator: QueryTermJoinOperatorKind.Or);
+            var result = Parse("wordone wordtwo", defaultJoinOperator: QueryTermJoinOperatorKind.Or);
             var expectedQuery = new OrQueryOperator(new ExactWordQueryPart("WORDONE"), new ExactWordQueryPart("WORDTWO"));
             VerifyResult(result, expectedQuery);
         }
@@ -36,7 +36,7 @@ namespace Lifti.Tests.Querying
         [Fact]
         public void AssumingFuzzySearch_ShouldTreatWordsAsFuzzySearch()
         {
-            var result = this.Parse("wordone", assumeFuzzy: true);
+            var result = Parse("wordone", assumeFuzzy: true);
             var expectedQuery = new FuzzyMatchQueryPart("WORDONE");
             VerifyResult(result, expectedQuery);
         }
@@ -44,7 +44,7 @@ namespace Lifti.Tests.Querying
         [Fact]
         public void AssumingFuzzySearch_WithFuzzyDefaults_ShouldTreatWordsAsFuzzySearch()
         {
-            var result = this.Parse("wordone", assumeFuzzy: true, x => (ushort)(x * 10), x => (ushort)(x * 20));
+            var result = Parse("wordone", assumeFuzzy: true, x => (ushort)(x * 10), x => (ushort)(x * 20));
             var expectedQuery = new FuzzyMatchQueryPart("WORDONE", 70, 140);
             VerifyResult(result, expectedQuery);
         }
@@ -54,7 +54,7 @@ namespace Lifti.Tests.Querying
             result.Root.ToString().Should().Be(expectedQuery.ToString());
         }
 
-        private IQuery Parse(
+        private static IQuery Parse(
             string text,
             bool assumeFuzzy = false,
             Func<int, ushort>? fuzzySearchMaxEditDistance = null,
@@ -83,7 +83,7 @@ namespace Lifti.Tests.Querying
             options.DefaultJoiningOperator = defaultJoinOperator;
 
             var parser = new SimpleQueryParser(options);
-            return parser.Parse(null, text, new IndexTokenizer(new TokenizationOptions()));
+            return parser.Parse(null!, text, new FakeIndexTokenizerProvider(new IndexTokenizer(new TokenizationOptions())));
         }
     }
 }

--- a/test/Lifti.Tests/Querying/SimpleQueryParserTests.cs
+++ b/test/Lifti.Tests/Querying/SimpleQueryParserTests.cs
@@ -83,7 +83,7 @@ namespace Lifti.Tests.Querying
             options.DefaultJoiningOperator = defaultJoinOperator;
 
             var parser = new SimpleQueryParser(options);
-            return parser.Parse(null, text, new Tokenizer(new TokenizationOptions()));
+            return parser.Parse(null, text, new IndexTokenizer(new TokenizationOptions()));
         }
     }
 }

--- a/test/Lifti.Tests/Querying/UnionMergerTests.cs
+++ b/test/Lifti.Tests/Querying/UnionMergerTests.cs
@@ -36,9 +36,12 @@ namespace Lifti.Tests.Querying
             var rightLeftResult = UnionMerger.Apply(right, left);
 
             leftRightResult.Should().BeEquivalentTo(
-                ScoredToken(1, ScoredFieldMatch(1D, 1, 30)),
-                ScoredToken(6, ScoredFieldMatch(6D, 1, 20, 60)),
-                ScoredToken(9, ScoredFieldMatch(8D, 1, 10, 80)));
+                new[]
+                {
+                    ScoredToken(1, ScoredFieldMatch(1D, 1, 30)),
+                    ScoredToken(6, ScoredFieldMatch(6D, 1, 20, 60)),
+                    ScoredToken(9, ScoredFieldMatch(8D, 1, 10, 80))
+                });
 
             leftRightResult.Should().BeEquivalentTo(rightLeftResult);
         }

--- a/test/Lifti.Tests/Querying/WildcardQueryPartParserTests.cs
+++ b/test/Lifti.Tests/Querying/WildcardQueryPartParserTests.cs
@@ -15,7 +15,7 @@ namespace Lifti.Tests.Querying
         [Fact]
         public void TextOnly_ShouldReturnFalse()
         {
-            RunTest("Foo", null, false);
+            RunTest("Foo", null!, false);
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace Lifti.Tests.Querying
         [Fact]
         public void SingleWildcardFollowingMultiple_ShouldThrowException()
         {
-            Assert.Throws<QueryParserException>(() => RunTest("****%", null));
+            Assert.Throws<QueryParserException>(() => RunTest("****%", null!));
         }
 
         [Fact]
@@ -54,12 +54,15 @@ namespace Lifti.Tests.Querying
             RunTest("%%foo*bar", new WildcardQueryPart(SingleCharacter, SingleCharacter, CreateText("FOO"), MultiCharacter, CreateText("BAR")));
         }
 
-        private static void RunTest(string text, WildcardQueryPart expectedQueryPart, bool expectedResult = true)
+        private static void RunTest(string text, WildcardQueryPart? expectedQueryPart, bool expectedResult = true)
         {
-            var result = WildcardQueryPartParser.TryParse(text, new FakeTokenizer(normalizeToUppercase: true), out var part);
+            var result = WildcardQueryPartParser.TryParse(text, new FakeIndexTokenizer(normalizeToUppercase: true), out var part);
 
             result.Should().Be(expectedResult);
-            part.Should().BeEquivalentTo(expectedQueryPart);
+            if (expectedQueryPart != null)
+            {
+                part!.Fragments.Should().BeEquivalentTo(expectedQueryPart.Fragments);
+            }
         }
     }
 }

--- a/test/Lifti.Tests/Tokenization/IndexTokenizerTests.cs
+++ b/test/Lifti.Tests/Tokenization/IndexTokenizerTests.cs
@@ -25,7 +25,7 @@ namespace Lifti.Tests.Tokenization
         {
             var sut = WithConfiguration();
 
-            var output = Execute(sut, new string[] { null });
+            var output = Execute(sut, new string[] { null! });
 
             output.Should().BeEmpty();
         }
@@ -42,8 +42,8 @@ namespace Lifti.Tests.Tokenization
 
         protected static IndexTokenizer WithConfiguration(
             bool splitOnPunctuation = true,
-            char[] additionalSplitChars = null,
-            char[] ignoreChars = null,
+            char[]? additionalSplitChars = null,
+            char[]? ignoreChars = null,
             bool caseInsensitive = false,
             bool accentInsensitive = false)
         {

--- a/test/Lifti.Tests/Tokenization/IndexTokenizerTests.cs
+++ b/test/Lifti.Tests/Tokenization/IndexTokenizerTests.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Lifti.Tokenization;
 using Lifti.Tokenization.TextExtraction;
-using Microsoft.VisualStudio.TestPlatform.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,7 +8,7 @@ using Xunit;
 
 namespace Lifti.Tests.Tokenization
 {
-    public abstract class TokenizerTests
+    public abstract class IndexTokenizerTests
     {
         [Fact]
         public void ShouldReturnNoTokensForEmptyString()
@@ -41,14 +40,14 @@ namespace Lifti.Tests.Tokenization
             output.Should().BeEmpty();
         }
 
-        protected static Tokenizer WithConfiguration(
-            bool splitOnPunctuation = true, 
+        protected static IndexTokenizer WithConfiguration(
+            bool splitOnPunctuation = true,
             char[] additionalSplitChars = null,
             char[] ignoreChars = null,
-            bool caseInsensitive = false, 
+            bool caseInsensitive = false,
             bool accentInsensitive = false)
         {
-            return new Tokenizer(
+            return new IndexTokenizer(
                 new TokenizationOptions()
                 {
                     SplitOnPunctuation = splitOnPunctuation,
@@ -59,7 +58,7 @@ namespace Lifti.Tests.Tokenization
                 });
         }
 
-        protected static IReadOnlyList<Token> Execute(Tokenizer tokenizer, params string[] textParts)
+        protected static IReadOnlyList<Token> Execute(IndexTokenizer tokenizer, params string[] textParts)
         {
             var fragments = new List<DocumentTextFragment>();
             var offset = 0;
@@ -72,7 +71,7 @@ namespace Lifti.Tests.Tokenization
             return tokenizer.Process(fragments);
         }
 
-        public class WithIgnoredCharacters : TokenizerTests
+        public class WithIgnoredCharacters : IndexTokenizerTests
         {
             [Fact]
             public void WhenIgnoredCharacterIsAlsoSplitCharacter_ShouldNotSplitOnCharacter()
@@ -100,9 +99,9 @@ namespace Lifti.Tests.Tokenization
             }
         }
 
-        public class WithAllInsensitivityProcessors : TokenizerTests
+        public class WithAllInsensitivityProcessors : IndexTokenizerTests
         {
-            private readonly Tokenizer sut;
+            private readonly IndexTokenizer sut;
 
             public WithAllInsensitivityProcessors()
             {
@@ -174,7 +173,7 @@ namespace Lifti.Tests.Tokenization
             }
         }
 
-        public class WithNoPreprocessors : TokenizerTests
+        public class WithNoPreprocessors : IndexTokenizerTests
         {
             [Fact]
             public void ShouldReturnSingleTokenForStringContainingOnlyOneWord()

--- a/test/Lifti.Tests/Tokenization/TextExtraction/PlainTextExtractorTests.cs
+++ b/test/Lifti.Tests/Tokenization/TextExtraction/PlainTextExtractorTests.cs
@@ -14,10 +14,10 @@ namespace Lifti.Tests.Tokenization.TextExtraction
             var sut = new PlainTextExtractor();
             var results = sut.Extract("Some text".AsMemory(), 10);
 
-            results.Select(r => (r.Offset, r.Text.ToString()))
-            .Should().BeEquivalentTo(
+            results.Select(r => (r.Offset, r.Text.ToString())).Should().BeEquivalentTo(new[]
+            {
                 (10, "Some text")
-            );
+            });
         }
     }
 }

--- a/test/Lifti.Tests/Tokenization/TextExtraction/XmlTextExtractorTests.cs
+++ b/test/Lifti.Tests/Tokenization/TextExtraction/XmlTextExtractorTests.cs
@@ -82,13 +82,14 @@ namespace Lifti.Tests.Tokenization.TextExtraction
 
             var results = index.Search("test");
 
-            results.Single().FieldMatches.Single().Locations.Should().BeEquivalentTo(
+            results.Single().FieldMatches.Single().Locations.Should().BeEquivalentTo(new[]
+            {
                 new TokenLocation(0, 5, 4),
                 new TokenLocation(1, 13, 4),
                 new TokenLocation(2, 25, 7),
                 new TokenLocation(3, 37, 4),
                 new TokenLocation(4, 42, 6)
-            );
+            });
         }
     }
 }

--- a/test/Lifti.Tests/TokenizerBuilderTests.cs
+++ b/test/Lifti.Tests/TokenizerBuilderTests.cs
@@ -21,7 +21,7 @@ namespace Lifti.Tests
         public void WithoutChangingTokenizerFactory_ShouldBuildTokenizer()
         {
             var builder = new TokenizerBuilder();
-            builder.Build().Should().BeOfType<Tokenizer>();
+            builder.Build().Should().BeOfType<IndexTokenizer>();
         }
 
         [Fact]
@@ -37,7 +37,7 @@ namespace Lifti.Tests
         public void WithoutApplyingAnyOptions_ShouldSetDefaultsCorrectly()
         {
             var builder = new TokenizerBuilder();
-            builder.Build().Should().BeOfType<Tokenizer>().Subject
+            builder.Build().Should().BeOfType<IndexTokenizer>().Subject
                 .Options.Should().BeEquivalentTo(expectedDefaultOptions);
         }
 
@@ -48,7 +48,7 @@ namespace Lifti.Tests
         {
             var builder = new TokenizerBuilder();
             builder.WithStemming(setting);
-            builder.Build().Should().BeOfType<Tokenizer>().Subject.Options.Stemming.Should().Be(setting);
+            builder.Build().Should().BeOfType<IndexTokenizer>().Subject.Options.Stemming.Should().Be(setting);
         }
 
         [Theory]
@@ -58,7 +58,7 @@ namespace Lifti.Tests
         {
             var builder = new TokenizerBuilder();
             builder.CaseInsensitive(setting);
-            builder.Build().Should().BeOfType<Tokenizer>().Subject.Options.CaseInsensitive.Should().Be(setting);
+            builder.Build().Should().BeOfType<IndexTokenizer>().Subject.Options.CaseInsensitive.Should().Be(setting);
         }
 
         [Theory]
@@ -68,7 +68,7 @@ namespace Lifti.Tests
         {
             var builder = new TokenizerBuilder();
             builder.AccentInsensitive(setting);
-            builder.Build().Should().BeOfType<Tokenizer>().Subject.Options.AccentInsensitive.Should().Be(setting);
+            builder.Build().Should().BeOfType<IndexTokenizer>().Subject.Options.AccentInsensitive.Should().Be(setting);
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace Lifti.Tests
         {
             var builder = new TokenizerBuilder();
             builder.SplitOnPunctuation(setting);
-            builder.Build().Should().BeOfType<Tokenizer>().Subject.Options.SplitOnPunctuation.Should().Be(setting);
+            builder.Build().Should().BeOfType<IndexTokenizer>().Subject.Options.SplitOnPunctuation.Should().Be(setting);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ namespace Lifti.Tests
         {
             var builder = new TokenizerBuilder();
             builder.SplitOnCharacters('$', '%', '|');
-            builder.Build().Should().BeOfType<Tokenizer>().Subject.Options.AdditionalSplitCharacters.Should().BeEquivalentTo(new[] { '$', '%', '|' });
+            builder.Build().Should().BeOfType<IndexTokenizer>().Subject.Options.AdditionalSplitCharacters.Should().BeEquivalentTo(new[] { '$', '%', '|' });
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace Lifti.Tests
         {
             var builder = new TokenizerBuilder();
             builder.IgnoreCharacters('\'', '`');
-            builder.Build().Should().BeOfType<Tokenizer>().Subject.Options.IgnoreCharacters.Should().BeEquivalentTo(new[] { '\'', '`' });
+            builder.Build().Should().BeOfType<IndexTokenizer>().Subject.Options.IgnoreCharacters.Should().BeEquivalentTo(new[] { '\'', '`' });
         }
     }
 }

--- a/test/Lifti.Tests/TokenizerBuilderTests.cs
+++ b/test/Lifti.Tests/TokenizerBuilderTests.cs
@@ -28,8 +28,8 @@ namespace Lifti.Tests
         public void WithSpecifiedTokenizerFactory_ShouldReturnConfiguredType()
         {
             var builder = new TokenizerBuilder();
-            builder.WithFactory(o => new FakeTokenizer(o) );
-            builder.Build().Should().BeOfType<FakeTokenizer>().Subject
+            builder.WithFactory(o => new FakeIndexTokenizer(o) );
+            builder.Build().Should().BeOfType<FakeIndexTokenizer>().Subject
                 .Options.Should().BeEquivalentTo(expectedDefaultOptions);
         }
 


### PR DESCRIPTION
* Improves differentiation of tokenization for indexes and queries by renaming ITokenizer to IIndexTokenizer
* LIFTI query parser can now apply field-level tokenizers when splitting tokens

Breaking changes:

* `ITokenizer` -> `IIndexTokenizer`
* `IFullTextIndex<T>` implements new interface `IIndexTokenizerProvider` that allows other components to easily access the various tokenizers in an index
* `IQueryParser.Parse` takes `IIndexTokenizerProvider` as a parameter instead of a single tokenizer