### PR TITLE
Removing ImmutableCollections

### DIFF
--- a/src/Lifti.Core/AssemblyInfo.cs
+++ b/src/Lifti.Core/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Lifti.Tests")]
+[assembly: InternalsVisibleTo("PerformanceProfiling")]
 
 namespace System.Runtime.CompilerServices
 {

--- a/src/Lifti.Core/ChildNodeMap.cs
+++ b/src/Lifti.Core/ChildNodeMap.cs
@@ -178,7 +178,7 @@ namespace Lifti
         /// <summary>
         /// Gets the set of characters that link from this instance to the child nodes.
         /// </summary>
-        internal IReadOnlyList<ChildNodeMapEntry> CharacterMap => this.childNodes;
+        public IReadOnlyList<ChildNodeMapEntry> CharacterMap => this.childNodes;
 
         internal ChildNodeMapMutation StartMutation()
         {

--- a/src/Lifti.Core/ChildNodeMap.cs
+++ b/src/Lifti.Core/ChildNodeMap.cs
@@ -1,0 +1,243 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+
+namespace Lifti
+{
+    internal sealed class ChildNodeMapMutation
+    {
+        private readonly ChildNodeMap? original;
+        private readonly Dictionary<char, IndexNodeMutation> mutated;
+
+        public ChildNodeMapMutation(char splitChar, IndexNodeMutation splitChildNode)
+        {
+            this.mutated = new()
+            {
+                { splitChar, splitChildNode }
+            };
+        }
+
+        internal ChildNodeMapMutation(ChildNodeMap original)
+        {
+            this.original = original;
+            this.mutated = [];
+        }
+
+        public IEnumerable<(char childCharacter, IndexNodeMutation childNode)> GetMutated()
+        {
+            foreach (var child in this.mutated)
+            {
+                yield return (child.Key, child.Value);
+            }
+        }
+
+        public IEnumerable<(char childCharacter, IndexNode childNode)> GetUnmutated()
+        {
+            if (this.original is { } originalChildNodeMap)
+            {
+                foreach (var (childCharacter, childNode) in originalChildNodeMap.Enumerate())
+                {
+                    if (!this.mutated.ContainsKey(childCharacter))
+                    {
+                        yield return (childCharacter, childNode);
+                    }
+                }
+            }
+        }
+
+        internal ChildNodeMap Apply()
+        {
+            // Combine the original and mutated children.
+            // We need to ensure:
+            // 1. mutated children in the original list are replaced with the mutated version
+            // 2. mutated children not in the original list are added to the list
+            // 3. the resulting list is sorted in ascending order
+            var newCount = this.mutated.Values.Where(x => x.IsNewNode).Count();
+            List<(char childChar, IndexNode childNode)> newChildNodes;
+
+            if (this.original is { } originalChildNodeMap)
+            {
+                newChildNodes = new(newCount + originalChildNodeMap.Count);
+                foreach (var (childChar, childNode) in originalChildNodeMap.Enumerate())
+                {
+                    if (this.mutated.ContainsKey(childChar) == false)
+                    {
+                        // This child node is not mutated, so add it to the list
+                        newChildNodes.Add((childChar, childNode));
+                    }
+                }
+            }
+            else
+            {
+                newChildNodes = new(newCount);
+            }
+
+            // Add the mutated children to the list
+            foreach (var mutation in this.mutated)
+            {
+                newChildNodes.Add((mutation.Key, mutation.Value.Apply()));
+            }
+
+            // Sort the list in-place
+            newChildNodes.Sort((x, y) => x.childChar.CompareTo(y.childChar));
+
+            return new ChildNodeMap(newChildNodes);
+        }
+
+        internal IndexNodeMutation GetOrCreateMutation(char indexChar, Func<IndexNodeMutation> createMutatedNode)
+        {
+            if (!this.mutated.TryGetValue(indexChar, out var mutation))
+            {
+                mutation = createMutatedNode();
+                this.Mutate(indexChar, mutation);
+            }
+
+            return mutation;
+        }
+
+        internal void Mutate(char childChar, IndexNodeMutation mutatedChild)
+        {
+            this.mutated[childChar] = mutatedChild;
+        }
+
+        internal void ToString(StringBuilder builder, int depth)
+        {
+            foreach (var (character, childNode) in this.GetUnmutated())
+            {
+                builder.AppendLine();
+                childNode.ToString(builder, character, depth);
+            }
+
+            foreach (var (character, childNode) in this.GetMutated())
+            {
+                builder.AppendLine();
+                childNode.ToString(builder, character, depth);
+            }
+        }
+    }
+
+    /// <summary>
+    /// An immutable map of child nodes.
+    /// </summary>
+    public readonly struct ChildNodeMap : IEquatable<ChildNodeMap>
+    {
+        private readonly char[] childChars;
+        private readonly IndexNode[] childNodes;
+
+        internal ChildNodeMap(List<(char childChar, IndexNode childNode)> map)
+        {
+            // Verify that the map is sorted
+#if DEBUG
+            for (var i = 1; i < map.Count; i++)
+            {
+                Debug.Assert(map[i - 1].childChar < map[i].childChar);
+            }
+#endif
+
+            this.childChars = new char[map.Count];
+            this.childNodes = new IndexNode[map.Count];
+
+            for (var i = 0; i < map.Count; i++)
+            {
+                this.childChars[i] = map[i].childChar;
+                this.childNodes[i] = map[i].childNode;
+            }
+        }
+
+        private ChildNodeMap(char[] childChars, IndexNode[] childNodes)
+        {
+            this.childNodes = childNodes;
+            this.childChars = childChars;
+        }
+
+        /// <summary>
+        /// Gets an empty instance of <see cref="ChildNodeMap"/>.
+        /// </summary>
+        public static ChildNodeMap Empty { get; } = new ChildNodeMap([], []);
+
+        /// <summary>
+        /// Gets the number of child nodes in the map.
+        /// </summary>
+        public int Count => this.childChars.Length;
+
+        /// <summary>
+        /// Gets the set of characters that link from this instance to the child nodes.
+        /// </summary>
+        public ReadOnlyMemory<char> Characters => this.childChars;
+
+        internal ChildNodeMapMutation StartMutation()
+        {
+            return new ChildNodeMapMutation(this);
+        }
+
+        /// <summary>
+        /// Enumerates all the child nodes in the map.
+        /// </summary>
+        public IEnumerable<(char character, IndexNode childNode)> Enumerate()
+        {
+            for (var i = 0; i < this.childChars.Length; i++)
+            {
+                yield return (this.childChars[i], this.childNodes[i]);
+            }
+        }
+
+        /// <summary>
+        /// Tries to get the child node for the specified character.
+        /// </summary>
+        public bool TryGetValue(char value, [NotNullWhen(true)] out IndexNode? nextNode)
+        {
+            if (this.childChars.Length == 0)
+            {
+                nextNode = null;
+                return false;
+            }
+
+            // TODO: Is this faster if we check for the value being outside the range of the array first?
+            var index = Array.BinarySearch(this.childChars, value);
+            if (index < 0)
+            {
+                nextNode = null;
+                return false;
+            }
+
+            nextNode = this.childNodes[index];
+            return true;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj)
+        {
+            // Because we're immutable, we can use reference equality
+            return obj is ChildNodeMap other
+                && this.Equals(other);
+        }
+
+        /// <inheritdoc />
+        public bool Equals(ChildNodeMap other)
+        {
+            return other.childNodes == this.childNodes
+                && other.childChars == this.childChars;
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.childChars, this.childNodes);
+        }
+
+        /// <inheritdoc />
+        public static bool operator ==(ChildNodeMap left, ChildNodeMap right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <inheritdoc />
+        public static bool operator !=(ChildNodeMap left, ChildNodeMap right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/src/Lifti.Core/DocumentStatistics.cs
+++ b/src/Lifti.Core/DocumentStatistics.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 
 namespace Lifti
@@ -12,7 +11,7 @@ namespace Lifti
     {
         internal DocumentStatistics(byte fieldId, int tokenCount)
         {
-            this.TokenCountByField = ImmutableDictionary<byte, int>.Empty.Add(fieldId, tokenCount);
+            this.TokenCountByField = new Dictionary<byte, int>() { { fieldId, tokenCount } };
             this.TotalTokenCount = tokenCount;
         }
 

--- a/src/Lifti.Core/DocumentTokenMatchMap.cs
+++ b/src/Lifti.Core/DocumentTokenMatchMap.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Lifti
@@ -131,6 +132,14 @@ namespace Lifti
             {
                 yield return (document.Key, document.Value);
             }
+        }
+
+        /// <summary>
+        /// Tries to get the list of indexed tokens for the specified document.
+        /// </summary>
+        public bool TryGetValue(int documentId, [NotNullWhen(true)] out IReadOnlyList<IndexedToken>? tokens)
+        {
+            return this.documentTokens.TryGetValue(documentId, out tokens);
         }
 
         /// <summary>

--- a/src/Lifti.Core/DocumentTokenMatchMap.cs
+++ b/src/Lifti.Core/DocumentTokenMatchMap.cs
@@ -1,0 +1,195 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Lifti
+{
+    internal sealed class DocumentTokenMatchMapMutation
+    {
+        private readonly DocumentTokenMatchMap original;
+        private HashSet<int>? removed;
+        private Dictionary<int, List<IndexedToken>>? mutated;
+
+        public DocumentTokenMatchMapMutation(DocumentTokenMatchMap original)
+        {
+            this.original = original;
+        }
+
+        public DocumentTokenMatchMap Apply()
+        {
+            if (this.mutated == null && this.removed == null)
+            {
+                return this.original;
+            }
+
+            // Copy the original matches except any that have been expressly removed
+            var remainingOriginalMatches = this.removed == null
+                ? this.original.Enumerate()
+                : this.original.Enumerate().Where(x => !this.removed.Contains(x.documentId));
+
+            Dictionary<int, IReadOnlyList<IndexedToken>> mutatedMatches;
+            if (this.mutated == null)
+            {
+                // Just create a new dictionary with the remaining original matches
+                mutatedMatches = remainingOriginalMatches.ToDictionary(x => x.documentId, x => x.indexedTokens);
+            }
+            else
+            {
+                // Copy any unmutated matches that haven't been removed into the mutated matches dictionary
+                mutatedMatches = this.mutated.ToDictionary(x => x.Key, x => (IReadOnlyList<IndexedToken>)x.Value);
+                foreach (var (documentId, indexedTokens) in remainingOriginalMatches)
+                {
+#if NETSTANDARD
+                    if (!mutatedMatches.ContainsKey(documentId))
+                    {
+                        mutatedMatches.Add(documentId, indexedTokens);
+                    }
+#else
+                    mutatedMatches.TryAdd(documentId, indexedTokens);
+#endif
+                }
+            }
+
+            return new DocumentTokenMatchMap(mutatedMatches);
+        }
+
+        public int MutationCount => this.mutated?.Count ?? 0;
+
+        public void Remove(int documentId)
+        {
+            if (this.removed == null)
+            {
+                this.removed = [documentId];
+            }
+            else
+            {
+                this.removed.Add(documentId);
+            }
+
+            // It's technically possible for a document to be added to the index, and in the same mutation removed
+            // again. In this case, we can just remove it from the mutations dictionary as if it was never
+            // added to it.
+            this.mutated?.Remove(documentId);
+        }
+
+        internal void Add(int documentId, IndexedToken indexedToken)
+        {
+            this.mutated ??= [];
+
+            if (this.mutated.TryGetValue(documentId, out var itemFieldLocations))
+            {
+                // The field locations list will already have been cloned when it was added to the mutations dictionary
+                // so it's safe to just add to it here
+                itemFieldLocations.Add(indexedToken);
+            }
+            else
+            {
+                itemFieldLocations = this.original.StartMutation(documentId);
+                itemFieldLocations.Add(indexedToken);
+                this.mutated.Add(documentId, itemFieldLocations);
+            }
+        }
+    }
+
+    /// <summary>
+    /// A read only map of <see cref="IndexedToken"/>s keyed by the internal item id.
+    /// </summary>
+    public readonly struct DocumentTokenMatchMap : IEquatable<DocumentTokenMatchMap>
+    {
+        private readonly Dictionary<int, IReadOnlyList<IndexedToken>> documentTokens;
+
+        internal DocumentTokenMatchMap(IEnumerable<KeyValuePair<int, IReadOnlyList<IndexedToken>>> data)
+        {
+#if NETSTANDARD
+            this.documentTokens = data.ToDictionary(x => x.Key, x => x.Value);
+#else
+            this.documentTokens = new(data);
+#endif
+        }
+
+        internal DocumentTokenMatchMap(Dictionary<int, IReadOnlyList<IndexedToken>> data)
+        {
+            this.documentTokens = data;
+        }
+
+        /// <summary>
+        /// Gets an empty <see cref="DocumentTokenMatchMap"/>.
+        /// </summary>
+        public static DocumentTokenMatchMap Empty { get; } = new DocumentTokenMatchMap(Array.Empty<KeyValuePair<int, IReadOnlyList<IndexedToken>>>());
+
+        /// <summary>
+        /// Gets the number of documents in the map.
+        /// </summary>
+        public int Count => this.documentTokens.Count;
+
+        /// <summary>
+        /// Enumerates all the document matches in the map.
+        /// </summary>
+        public IEnumerable<(int documentId, IReadOnlyList<IndexedToken> indexedTokens)> Enumerate()
+        {
+            foreach (var document in this.documentTokens)
+            {
+                yield return (document.Key, document.Value);
+            }
+        }
+
+        /// <summary>
+        /// Begins mutation the list of indexed tokens for the specified document. If the document is not already
+        /// indexed at this node, a new empty list will be created. If the document is already indexed at this node,
+        /// a clone of the list will be created and returned, so is safe to be mutated.
+        /// </summary>
+        /// <param name="documentId"></param>
+        /// <returns></returns>
+        internal List<IndexedToken> StartMutation(int documentId)
+        {
+            if (this.documentTokens.TryGetValue(documentId, out var indexedTokens))
+            {
+                return new List<IndexedToken>(indexedTokens);
+            }
+            else
+            {
+                return [];
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the map contains any matches for the specified document.
+        /// </summary>
+        public bool HasDocument(int documentId)
+        {
+            return this.documentTokens.ContainsKey(documentId);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            return obj is DocumentTokenMatchMap other
+                && this.Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(DocumentTokenMatchMap other)
+        {
+            // Because we're immutable, we can just compare the references
+            return this.documentTokens == other.documentTokens;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return this.documentTokens.GetHashCode();
+        }
+
+        /// <inheritdoc/>
+        public static bool operator ==(DocumentTokenMatchMap left, DocumentTokenMatchMap right)
+        {
+            return left.Equals(right);
+        }
+
+        /// <inheritdoc/>
+        public static bool operator !=(DocumentTokenMatchMap left, DocumentTokenMatchMap right)
+        {
+            return !(left == right);
+        }
+    }
+}

--- a/src/Lifti.Core/IIndexNodeFactory.cs
+++ b/src/Lifti.Core/IIndexNodeFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Immutable;
 
 namespace Lifti
 {
@@ -30,8 +29,8 @@ namespace Lifti
         /// </param>
         IndexNode CreateNode(
             ReadOnlyMemory<char> intraNodeText,
-            ImmutableDictionary<char, IndexNode> childNodes,
-            ImmutableDictionary<int, ImmutableList<IndexedToken>> matches);
+            ChildNodeMap childNodes,
+            DocumentTokenMatchMap matches);
 
         /// <summary>
         /// Gets the <see cref="IndexSupportLevelKind"/> for the given <paramref name="depth"/> into the index.

--- a/src/Lifti.Core/IItemStore.cs
+++ b/src/Lifti.Core/IItemStore.cs
@@ -69,11 +69,6 @@ namespace Lifti
         ItemMetadata<TKey> GetMetadata(TKey key);
 
         /// <summary>
-        /// Creates a snapshot of this instance that can be used even if the index is subsequently mutated.
-        /// </summary>
-        IItemStore<TKey> Snapshot();
-
-        /// <summary>
         /// Adds the given item metadata to the item store. This should only be used by deserializers as they 
         /// rebuild the index.
         /// </summary>

--- a/src/Lifti.Core/IndexMutation.cs
+++ b/src/Lifti.Core/IndexMutation.cs
@@ -3,14 +3,21 @@ using System;
 
 namespace Lifti
 {
-    internal class IndexMutation
+    internal class IndexMutation<TKey>
+        where TKey : notnull
     {
         private readonly IndexNodeMutation root;
 
-        public IndexMutation(IndexNode root, IIndexNodeFactory indexNodeFactory)
+        public IndexMutation(
+            IndexNode root,
+            ItemStore<TKey> originalItemStore,
+            IIndexNodeFactory indexNodeFactory)
         {
             this.root = new IndexNodeMutation(0, root, indexNodeFactory);
+            this.ItemStore = new(originalItemStore);
         }
+
+        public ItemStore<TKey> ItemStore { get; }
 
         internal void Add(int itemId, byte fieldId, Token token)
         {

--- a/src/Lifti.Core/IndexNode.cs
+++ b/src/Lifti.Core/IndexNode.cs
@@ -91,7 +91,7 @@ namespace Lifti
         /// <param name="nextDepth"></param>
         internal void ToString(StringBuilder builder, int nextDepth)
         {
-            foreach (var (character, childNode) in this.ChildNodes.Enumerate())
+            foreach (var (character, childNode) in this.ChildNodes.CharacterMap)
             {
                 builder.AppendLine();
                 childNode.ToString(builder, character, nextDepth);
@@ -104,7 +104,7 @@ namespace Lifti
             {
                 var nextDepth = currentDepth + 1;
 
-                foreach (var (character, childNode) in this.ChildNodes.Enumerate())
+                foreach (var (character, childNode) in this.ChildNodes.CharacterMap)
                 {
                     builder.AppendLine();
                     childNode.ToString(builder, character, nextDepth);

--- a/src/Lifti.Core/IndexNode.cs
+++ b/src/Lifti.Core/IndexNode.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Text;
 
@@ -12,8 +11,8 @@ namespace Lifti
     {
         internal IndexNode(
             ReadOnlyMemory<char> intraNodeText,
-            ImmutableDictionary<char, IndexNode> childNodes,
-            ImmutableDictionary<int, ImmutableList<IndexedToken>> matches)
+            ChildNodeMap childNodes,
+            DocumentTokenMatchMap matches)
         {
             this.IntraNodeText = intraNodeText;
             this.ChildNodes = childNodes;
@@ -26,18 +25,18 @@ namespace Lifti
         /// text has been completely processed.
         /// </summary>
         public ReadOnlyMemory<char> IntraNodeText { get; }
-        
+
         /// <summary>
         /// Gets any child nodes that can be navigated to from this instance, once the intra-node text has 
         /// been processed.
         /// </summary>
-        public ImmutableDictionary<char, IndexNode> ChildNodes { get; }
+        public ChildNodeMap ChildNodes { get; }
 
         /// <summary>
         /// Gets the set of matches that are found at this location in the index (once all the <see cref="IntraNodeText"/>
         /// has been processed.)
         /// </summary>
-        public ImmutableDictionary<int, ImmutableList<IndexedToken>> Matches { get; }
+        public DocumentTokenMatchMap Matches { get; }
 
         /// <summary>
         /// Gets a value indicating whether this node is empty. A node is considered empty if it doesn't have 
@@ -71,6 +70,9 @@ namespace Lifti
             return builder.ToString();
         }
 
+        /// <summary>
+        /// Formats a single child node linked from this instance to the given <paramref name="builder"/>.
+        /// </summary>
         internal void ToString(StringBuilder builder, char linkChar, int currentDepth)
         {
             builder.Append(' ', currentDepth * 2)
@@ -82,15 +84,30 @@ namespace Lifti
             this.FormatChildNodeText(builder, currentDepth);
         }
 
+        /// <summary>
+        /// Formats all the child nodes of this instance to the given <paramref name="builder"/>.
+        /// </summary>
+        /// <param name="builder"></param>
+        /// <param name="nextDepth"></param>
+        internal void ToString(StringBuilder builder, int nextDepth)
+        {
+            foreach (var (character, childNode) in this.ChildNodes.Enumerate())
+            {
+                builder.AppendLine();
+                childNode.ToString(builder, character, nextDepth);
+            }
+        }
+
         private void FormatChildNodeText(StringBuilder builder, int currentDepth)
         {
             if (this.HasChildNodes)
             {
                 var nextDepth = currentDepth + 1;
-                foreach (var item in this.ChildNodes)
+
+                foreach (var (character, childNode) in this.ChildNodes.Enumerate())
                 {
                     builder.AppendLine();
-                    item.Value.ToString(builder, item.Key, nextDepth);
+                    childNode.ToString(builder, character, nextDepth);
                 }
             }
         }

--- a/src/Lifti.Core/IndexNodeFactory.cs
+++ b/src/Lifti.Core/IndexNodeFactory.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Immutable;
 
 namespace Lifti
 {
@@ -31,8 +30,8 @@ namespace Lifti
         {
             return new IndexNode(
                 null,
-                ImmutableDictionary<char, IndexNode>.Empty,
-                ImmutableDictionary<int, ImmutableList<IndexedToken>>.Empty);
+                ChildNodeMap.Empty,
+                DocumentTokenMatchMap.Empty);
         }
 
         /// <inheritdoc/>
@@ -46,8 +45,8 @@ namespace Lifti
         /// <inheritdoc/>
         public IndexNode CreateNode(
             ReadOnlyMemory<char> intraNodeText,
-            ImmutableDictionary<char, IndexNode> childNodes,
-            ImmutableDictionary<int, ImmutableList<IndexedToken>> matches)
+            ChildNodeMap childNodes,
+            DocumentTokenMatchMap matches)
         {
             return new IndexNode(intraNodeText, childNodes, matches);
         }

--- a/src/Lifti.Core/IndexNodeMutation.cs
+++ b/src/Lifti.Core/IndexNodeMutation.cs
@@ -47,8 +47,6 @@ namespace Lifti
 
         public DocumentTokenMatchMapMutation? DocumentTokenMatchMapMutation { get; private set; }
 
-        public bool IsNewNode => this.original == null;
-
         internal void Index(
             int itemId,
             byte fieldId,
@@ -112,7 +110,7 @@ namespace Lifti
                 else if (this.original != null)
                 {
                     // Then any unmutated children
-                    foreach (var (childChar, childNode) in this.original.ChildNodes.Enumerate())
+                    foreach (var (childChar, childNode) in this.original.ChildNodes.CharacterMap)
                     {
                         if (this.TryRemove(childNode, documentId, this.depth + 1, out var mutatedChild))
                         {
@@ -149,7 +147,7 @@ namespace Lifti
             {
                 // Work through the child nodes and recursively determine whether removals are needed from 
                 // them. If they are, then this instance will also become mutated.
-                foreach (var (character, childNode) in node.ChildNodes.Enumerate())
+                foreach (var (character, childNode) in node.ChildNodes.CharacterMap)
                 {
                     if (this.TryRemove(childNode, documentId, nodeDepth + 1, out var mutatedChild))
                     {

--- a/src/Lifti.Core/IndexSnapshot.cs
+++ b/src/Lifti.Core/IndexSnapshot.cs
@@ -8,14 +8,16 @@ namespace Lifti
     {
         private readonly IIndexNavigatorPool indexNavigatorPool;
 
-        internal IndexSnapshot(IIndexNavigatorPool indexNavigatorPool, FullTextIndex<TKey> index)
+        internal IndexSnapshot(
+            IIndexNavigatorPool indexNavigatorPool,
+            IIndexedFieldLookup fieldLookup,
+            IndexNode rootNode,
+            IItemStore<TKey> itemStore)
         {
-            this.Items = index.Items.Snapshot();
-            this.Root = index.Root;
+            this.Items = itemStore;
+            this.Root = rootNode;
             this.indexNavigatorPool = indexNavigatorPool;
-
-            // Field lookup is read-only once the index is constructed
-            this.FieldLookup = index.FieldLookup;
+            this.FieldLookup = fieldLookup;
         }
 
         /// <inheritdoc />

--- a/src/Lifti.Core/IndexStatistics.cs
+++ b/src/Lifti.Core/IndexStatistics.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 
 namespace Lifti
 {
@@ -8,56 +8,75 @@ namespace Lifti
     /// </summary>
     public class IndexStatistics
     {
-        private IndexStatistics()
+        private readonly Dictionary<byte, long> tokenCountByField;
+
+        internal IndexStatistics()
         {
-            this.TokenCountByField = ImmutableDictionary<byte, long>.Empty;
+            this.tokenCountByField = [];
         }
 
-        internal IndexStatistics(ImmutableDictionary<byte, long> tokenCountByField, long totalTokenCount)
+        /// <summary>
+        /// Creates a copy of the specified <see cref="IndexStatistics"/> instance and safe to mutate.
+        /// </summary>
+        internal IndexStatistics(IndexStatistics original)
         {
-            this.TokenCountByField = tokenCountByField;
+            this.tokenCountByField = new(original.tokenCountByField);
+            this.TotalTokenCount = original.TotalTokenCount;
+        }
+
+        internal IndexStatistics(Dictionary<byte, long> tokenCountByField, long totalTokenCount)
+        {
+            this.tokenCountByField = tokenCountByField;
             this.TotalTokenCount = totalTokenCount;
         }
 
-        internal static IndexStatistics Empty { get; } = new IndexStatistics();
-
         /// <summary>
-        /// Gets a dictionary containing the token count for each field indexed in the index.
+        /// Gets the token count for the specified field.
         /// </summary>
-        public ImmutableDictionary<byte, long> TokenCountByField { get; }
+        public long GetFieldTokenCount(byte fieldId)
+        {
+            if (!this.tokenCountByField.TryGetValue(fieldId, out var tokenCount))
+            {
+                throw new LiftiException(ExceptionMessages.UnknownField, fieldId);
+            }
+
+            return tokenCount;
+        }
 
         /// <summary>
         /// Gets the total token count for all documents in the index.
         /// </summary>
-        public long TotalTokenCount { get; }
+        public long TotalTokenCount { get; private set; }
 
-        internal IndexStatistics Remove(DocumentStatistics documentStatistics)
+        /// <summary>
+        /// Gets the total number of tokens stored each field in the index.
+        /// </summary>
+        public IReadOnlyDictionary<byte, long> TokenCountByField => this.tokenCountByField;
+
+        internal void Remove(DocumentStatistics documentStatistics)
         {
-            return Adjust(documentStatistics, -1);
+            this.Adjust(documentStatistics, -1);
         }
 
-        internal IndexStatistics Add(DocumentStatistics documentStatistics)
+        internal void Add(DocumentStatistics documentStatistics)
         {
-            return Adjust(documentStatistics, 1);
+            this.Adjust(documentStatistics, 1);
         }
 
-        private IndexStatistics Adjust(DocumentStatistics documentStatistics, int direction)
+        private void Adjust(DocumentStatistics documentStatistics, int direction)
         {
             if (documentStatistics is null)
             {
                 throw new ArgumentNullException(nameof(documentStatistics));
             }
 
-            var updatedFieldTokenCount = this.TokenCountByField;
             foreach (var fieldTokenCount in documentStatistics.TokenCountByField)
             {
-                updatedFieldTokenCount.TryGetValue(fieldTokenCount.Key, out var previousCount);
-                updatedFieldTokenCount = updatedFieldTokenCount.SetItem(fieldTokenCount.Key, previousCount + (fieldTokenCount.Value * direction));
+                this.tokenCountByField.TryGetValue(fieldTokenCount.Key, out var previousCount);
+                this.tokenCountByField[fieldTokenCount.Key] = previousCount + (fieldTokenCount.Value * direction);
             }
 
-            return new IndexStatistics(
-                updatedFieldTokenCount,
-                this.TotalTokenCount + (documentStatistics.TotalTokenCount * direction));
+            this.TotalTokenCount += documentStatistics.TotalTokenCount * direction;
         }
     }
 }

--- a/src/Lifti.Core/Lifti.Core.csproj
+++ b/src/Lifti.Core/Lifti.Core.csproj
@@ -23,6 +23,7 @@
 		<EnableNETAnalyzers>True</EnableNETAnalyzers>
 		<AnalysisLevel>latest-all</AnalysisLevel>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Lifti.Core/Lifti.Core.csproj
+++ b/src/Lifti.Core/Lifti.Core.csproj
@@ -23,7 +23,6 @@
 		<EnableNETAnalyzers>True</EnableNETAnalyzers>
 		<AnalysisLevel>latest-all</AnalysisLevel>
 		<EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
-		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Lifti.Core/Lifti.Core.csproj
+++ b/src/Lifti.Core/Lifti.Core.csproj
@@ -79,9 +79,6 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" Condition="'$(TargetFramework)' == 'netstandard2'" />
-		<PackageReference Include="System.Collections.Immutable" Version="1.7.1" Condition="'$(TargetFramework)' == 'netstandard2'" />
-		<PackageReference Include="System.Collections.Immutable" Version="6.0.0" Condition="'$(TargetFramework)' == 'net6.0'" />
-		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" Condition="'$(TargetFramework)' == 'net7.0'" />
 		<PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2'" />
 		<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2'"/>
 	</ItemGroup>

--- a/src/Lifti.Core/Querying/FieldMatch.cs
+++ b/src/Lifti.Core/Querying/FieldMatch.cs
@@ -82,7 +82,7 @@ namespace Lifti.Querying
 
         private static List<ITokenLocationMatch> CreateLocationsList(IEnumerable<ITokenLocationMatch> matches)
         {
-            return matches.OrderBy(x => x.MinTokenIndex).ToList();
+            return [.. matches.OrderBy(x => x.MinTokenIndex)];
         }
     }
 }

--- a/src/Lifti.Core/Querying/IndexNavigator.cs
+++ b/src/Lifti.Core/Querying/IndexNavigator.cs
@@ -85,7 +85,7 @@ namespace Lifti.Querying
 
                 if (node.HasChildNodes)
                 {
-                    foreach (var (_, childNode) in node.ChildNodes.Enumerate())
+                    foreach (var (_, childNode) in node.ChildNodes.CharacterMap)
                     {
                         childNodeStack.Enqueue(childNode);
                     }
@@ -193,10 +193,10 @@ namespace Lifti.Querying
                 }
                 else if (this.currentNode.HasChildNodes)
                 {
-                    var childChars = this.currentNode.ChildNodes.Characters;
-                    for (var i = 0; i < childChars.Length; i++)
+                    var childChars = this.currentNode.ChildNodes.CharacterMap;
+                    for (var i = 0; i < childChars.Count; i++)
                     {
-                        yield return childChars.Span[i];
+                        yield return childChars[i].ChildChar;
                     }
                 }
             }
@@ -244,7 +244,7 @@ namespace Lifti.Querying
 
             if (node.HasChildNodes)
             {
-                foreach (var (character, childNode) in node.ChildNodes.Enumerate())
+                foreach (var (character, childNode) in node.ChildNodes.CharacterMap)
                 {
                     this.navigatedWith.Append(character);
                     foreach (var result in this.EnumerateIndexedTokens(childNode))

--- a/src/Lifti.Core/Querying/QueryToken.cs
+++ b/src/Lifti.Core/Querying/QueryToken.cs
@@ -65,8 +65,10 @@ namespace Lifti.Querying
         /// The score boost to apply to any items matching the search term. This is multiplied with any score boosts
         /// applied to matching fields. A null value indicates that no additional score boost should be applied.
         /// </param>
-        public static QueryToken ForText(string text, IIndexTokenizer indexTokenizer, double? scoreBoost) 
-            => new QueryToken(text, QueryTokenType.Text, 0, indexTokenizer, scoreBoost);
+        public static QueryToken ForText(string text, IIndexTokenizer indexTokenizer, double? scoreBoost)
+        {
+            return new(text, QueryTokenType.Text, 0, indexTokenizer, scoreBoost);
+        }
 
         /// <summary>
         /// Creates a new <see cref="QueryToken"/> instance representing a field filter.
@@ -74,8 +76,10 @@ namespace Lifti.Querying
         /// <param name="fieldName">
         /// The name of the field to match.
         /// </param>
-        public static QueryToken ForFieldFilter(string fieldName) 
-            => new QueryToken(fieldName, QueryTokenType.FieldFilter, 0, null);
+        public static QueryToken ForFieldFilter(string fieldName)
+        {
+            return new(fieldName, QueryTokenType.FieldFilter, 0, null);
+        }
 
         /// <summary>
         /// Creates a new <see cref="QueryToken"/> instance representing a query operator.
@@ -83,8 +87,10 @@ namespace Lifti.Querying
         /// <param name="operatorType">
         /// The type of operator the token should represent.
         /// </param>
-        public static QueryToken ForOperator(QueryTokenType operatorType) 
-            => new QueryToken(string.Empty, operatorType, 0, null);
+        public static QueryToken ForOperator(QueryTokenType operatorType)
+        {
+            return new(string.Empty, operatorType, 0, null);
+        }
 
         /// <summary>
         /// Creates a new <see cref="QueryToken"/> instance representing a query operator that has additional positional constraints.
@@ -95,8 +101,10 @@ namespace Lifti.Querying
         /// <param name="tolerance">
         /// The number of tokens to use as the tolerance for the operator.
         /// </param>
-        public static QueryToken ForOperatorWithTolerance(QueryTokenType operatorType, int tolerance) => 
-            new QueryToken(string.Empty, operatorType, tolerance == 0 ? 5 : tolerance, null, null);
+        public static QueryToken ForOperatorWithTolerance(QueryTokenType operatorType, int tolerance)
+        {
+            return new(string.Empty, operatorType, tolerance == 0 ? 5 : tolerance, null, null);
+        }
 
         /// <inheritdoc />
         public override bool Equals(object? obj)

--- a/src/Lifti.Core/Serialization/Binary/IndexWriter.cs
+++ b/src/Lifti.Core/Serialization/Binary/IndexWriter.cs
@@ -84,10 +84,10 @@ namespace Lifti.Serialization.Binary
 
             if (childNodeCount > 0)
             {
-                foreach (var childNode in node.ChildNodes)
+                foreach (var (character, childNode) in node.ChildNodes.Enumerate())
                 {
-                    this.writer.WriteVarUInt16(childNode.Key);
-                    await this.WriteNodeAsync(childNode.Value).ConfigureAwait(false);
+                    this.writer.WriteVarUInt16(character);
+                    await this.WriteNodeAsync(childNode).ConfigureAwait(false);
                 }
             }
 
@@ -104,12 +104,12 @@ namespace Lifti.Serialization.Binary
 
         private void WriteMatchLocations(IndexNode node)
         {
-            foreach (var match in node.Matches)
+            foreach (var (documentId, matches) in node.Matches.Enumerate())
             {
-                this.writer.WriteNonNegativeVarInt32(match.Key);
-                this.writer.WriteNonNegativeVarInt32(match.Value.Count);
+                this.writer.WriteNonNegativeVarInt32(documentId);
+                this.writer.WriteNonNegativeVarInt32(matches.Count);
 
-                foreach (var fieldMatch in match.Value)
+                foreach (var fieldMatch in matches)
                 {
                     this.writer.Write(fieldMatch.FieldId);
                     this.writer.WriteNonNegativeVarInt32(fieldMatch.Locations.Count);

--- a/src/Lifti.Core/Serialization/Binary/IndexWriter.cs
+++ b/src/Lifti.Core/Serialization/Binary/IndexWriter.cs
@@ -84,7 +84,7 @@ namespace Lifti.Serialization.Binary
 
             if (childNodeCount > 0)
             {
-                foreach (var (character, childNode) in node.ChildNodes.Enumerate())
+                foreach (var (character, childNode) in node.ChildNodes.CharacterMap)
                 {
                     this.writer.WriteVarUInt16(character);
                     await this.WriteNodeAsync(childNode).ConfigureAwait(false);

--- a/src/Lifti.Core/Serialization/Binary/V2IndexReader.cs
+++ b/src/Lifti.Core/Serialization/Binary/V2IndexReader.cs
@@ -104,13 +104,13 @@ namespace Lifti.Serialization.Binary
             var matchCount = this.reader.ReadInt32();
             var childNodeCount = this.reader.ReadInt32();
             var intraNodeText = textLength == 0 ? null : this.ReadIntraNodeText(textLength);
-            var childNodes = childNodeCount > 0 ? new List<(char childChar, IndexNode childNode)>() : null;
+            var childNodes = childNodeCount > 0 ? new ChildNodeMapEntry[childNodeCount] : null;
             var matches = matchCount > 0 ? new Dictionary<int, IReadOnlyList<IndexedToken>>() : null;
 
             for (var i = 0; i < childNodeCount; i++)
             {
                 var matchChar = this.ReadMatchedCharacter();
-                childNodes!.Add((matchChar, this.DeserializeNode(nodeFactory, depth + 1)));
+                childNodes![i] = new(matchChar, this.DeserializeNode(nodeFactory, depth + 1));
             }
 
             for (var itemMatch = 0; itemMatch < matchCount; itemMatch++)

--- a/src/Lifti.Core/Serialization/Binary/V5IndexReader.cs
+++ b/src/Lifti.Core/Serialization/Binary/V5IndexReader.cs
@@ -105,13 +105,13 @@ namespace Lifti.Serialization.Binary
             var matchCount = this.reader.ReadNonNegativeVarInt32();
             var childNodeCount = this.reader.ReadNonNegativeVarInt32();
             var intraNodeText = textLength == 0 ? null : this.ReadIntraNodeText(textLength);
-            var childNodes = childNodeCount > 0 ? new List<(char childChar, IndexNode childNode)>() : null;
+            var childNodes = childNodeCount > 0 ? new ChildNodeMapEntry[childNodeCount] : null;
             var matches = matchCount > 0 ? new Dictionary<int, IReadOnlyList<IndexedToken>>() : null;
 
             for (var i = 0; i < childNodeCount; i++)
             {
                 var matchChar = (char)this.reader.ReadVarUInt16();
-                childNodes!.Add((matchChar, this.DeserializeNode(fieldIdMap, nodeFactory, depth + 1)));
+                childNodes![i] = new(matchChar, this.DeserializeNode(fieldIdMap, nodeFactory, depth + 1));
             }
 
             for (var itemMatch = 0; itemMatch < matchCount; itemMatch++)

--- a/src/Lifti.Core/Serialization/Binary/V5IndexReader.cs
+++ b/src/Lifti.Core/Serialization/Binary/V5IndexReader.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -82,7 +81,7 @@ namespace Lifti.Serialization.Binary
                 var id = this.reader.ReadNonNegativeVarInt32();
                 var key = this.keySerializer.Read(this.reader);
                 var fieldStatCount = (int)this.reader.ReadByte();
-                var fieldTokenCounts = ImmutableDictionary.CreateBuilder<byte, int>();
+                var fieldTokenCounts = new Dictionary<byte, int>(fieldStatCount);
                 var totalTokenCount = 0;
                 for (var fieldIndex = 0; fieldIndex < fieldStatCount; fieldIndex++)
                 {
@@ -92,7 +91,7 @@ namespace Lifti.Serialization.Binary
                     totalTokenCount += wordCount;
                 }
 
-                var documentStatistics = new DocumentStatistics(fieldTokenCounts.ToImmutable(), totalTokenCount);
+                var documentStatistics = new DocumentStatistics(fieldTokenCounts, totalTokenCount);
 
                 // Using ForLooseText here because we don't know any of the new information associated to an object
                 // type, e.g. its id or score boost options. This is the closest we can get to the old format.
@@ -106,22 +105,20 @@ namespace Lifti.Serialization.Binary
             var matchCount = this.reader.ReadNonNegativeVarInt32();
             var childNodeCount = this.reader.ReadNonNegativeVarInt32();
             var intraNodeText = textLength == 0 ? null : this.ReadIntraNodeText(textLength);
-            var childNodes = childNodeCount > 0 ? ImmutableDictionary.CreateBuilder<char, IndexNode>() : null;
-            var matches = matchCount > 0 ? ImmutableDictionary.CreateBuilder<int, ImmutableList<IndexedToken>>() : null;
+            var childNodes = childNodeCount > 0 ? new List<(char childChar, IndexNode childNode)>() : null;
+            var matches = matchCount > 0 ? new Dictionary<int, IReadOnlyList<IndexedToken>>() : null;
 
             for (var i = 0; i < childNodeCount; i++)
             {
                 var matchChar = (char)this.reader.ReadVarUInt16();
-                childNodes!.Add(matchChar, this.DeserializeNode(fieldIdMap, nodeFactory, depth + 1));
+                childNodes!.Add((matchChar, this.DeserializeNode(fieldIdMap, nodeFactory, depth + 1)));
             }
 
-            var locationMatches = new List<TokenLocation>(50);
             for (var itemMatch = 0; itemMatch < matchCount; itemMatch++)
             {
                 var itemId = this.reader.ReadNonNegativeVarInt32();
                 var fieldCount = this.reader.ReadNonNegativeVarInt32();
-
-                var indexedTokens = ImmutableList.CreateBuilder<IndexedToken>();
+                var indexedTokens = new IndexedToken[fieldCount];
 
                 for (var fieldMatch = 0; fieldMatch < fieldCount; fieldMatch++)
                 {
@@ -130,27 +127,19 @@ namespace Lifti.Serialization.Binary
                     var fieldId = fieldIdMap[this.reader.ReadByte()];
 
                     var locationCount = this.reader.ReadNonNegativeVarInt32();
-
-                    locationMatches.Clear();
-
-                    // Resize the collection immediately if required to prevent multiple resizes during deserialization
-                    if (locationMatches.Capacity < locationCount)
-                    {
-                        locationMatches.Capacity = locationCount;
-                    }
-
+                    var locationMatches = new List<TokenLocation>(locationCount);
                     this.ReadLocations(locationCount, locationMatches);
 
-                    indexedTokens.Add(new IndexedToken(fieldId, locationMatches.ToArray()));
+                    indexedTokens[fieldMatch] = new IndexedToken(fieldId, [.. locationMatches]);
                 }
 
-                matches!.Add(itemId, indexedTokens.ToImmutable());
+                matches!.Add(itemId, indexedTokens);
             }
 
             return nodeFactory.CreateNode(
                 intraNodeText,
-                childNodes?.ToImmutable() ?? ImmutableDictionary<char, IndexNode>.Empty,
-                matches?.ToImmutable() ?? ImmutableDictionary<int, ImmutableList<IndexedToken>>.Empty);
+                childNodes == null ? ChildNodeMap.Empty : new ChildNodeMap(childNodes),
+                matches == null ? DocumentTokenMatchMap.Empty : new DocumentTokenMatchMap(matches));
         }
 
         /// <summary>

--- a/src/Lifti.Core/Serialization/Binary/V6IndexReader.cs
+++ b/src/Lifti.Core/Serialization/Binary/V6IndexReader.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Lifti.Serialization.Binary
@@ -26,7 +26,7 @@ namespace Lifti.Serialization.Binary
                 var id = this.reader.ReadNonNegativeVarInt32();
                 var key = this.keySerializer.Read(this.reader);
                 var fieldStatCount = (int)this.reader.ReadByte();
-                var fieldTokenCounts = ImmutableDictionary.CreateBuilder<byte, int>();
+                var fieldTokenCounts = new Dictionary<byte, int>(fieldStatCount);
                 var totalTokenCount = 0;
                 for (var fieldIndex = 0; fieldIndex < fieldStatCount; fieldIndex++)
                 {
@@ -36,7 +36,7 @@ namespace Lifti.Serialization.Binary
                     totalTokenCount += wordCount;
                 }
 
-                var documentStatistics = new DocumentStatistics(fieldTokenCounts.ToImmutable(), totalTokenCount);
+                var documentStatistics = new DocumentStatistics(fieldTokenCounts, totalTokenCount);
 
                 // Now read the object type information, if any
                 var objectBitMaskInfo = this.reader.ReadByte();

--- a/test/Lifti.Tests/ChildNodeMapTests.cs
+++ b/test/Lifti.Tests/ChildNodeMapTests.cs
@@ -1,0 +1,83 @@
+﻿using FluentAssertions;
+using System;
+using Xunit;
+
+namespace Lifti.Tests
+{
+    public class ChildNodeMapTests
+    {
+        [Fact]
+        public void TryGetValue_WhenNoCharacters_ReturnsFalse()
+        {
+            var sut = new ChildNodeMap();
+            sut.TryGetValue('A', out var nextNode).Should().BeFalse();
+        }
+
+        [Fact]
+        public void TryGetValue_WithSingleMatchingCharacter_ReturnsMatch()
+        {
+            var sut = new ChildNodeMap([CreateTestIndexNodeMap('A')]);
+
+            this.VerifySuccessfulMatch(sut, 'A');
+            this.VerifyUnsuccessfulMatch(sut, 'B');
+            this.VerifyUnsuccessfulMatch(sut, 'a');
+        }
+
+        [Fact]
+        public void TryGetValue_WithTwoCharacters_ReturnsMatch()
+        {
+            var sut = new ChildNodeMap(
+                [
+                    CreateTestIndexNodeMap('A'),
+                    CreateTestIndexNodeMap('Z')
+                ]);
+
+            this.VerifySuccessfulMatch(sut, 'A');
+            this.VerifySuccessfulMatch(sut, 'Z');
+            this.VerifyUnsuccessfulMatch(sut, 'B');
+            this.VerifyUnsuccessfulMatch(sut, 'a');
+        }
+
+        [Fact]
+        public void TryGetValue_WithFiveCharacters_ReturnsMatch()
+        {
+            var sut = new ChildNodeMap(
+                [
+                    CreateTestIndexNodeMap('E'),
+                    CreateTestIndexNodeMap('H'),
+                    CreateTestIndexNodeMap('L'),
+                    CreateTestIndexNodeMap('N'),
+                    CreateTestIndexNodeMap('P')
+                ]);
+
+            this.VerifySuccessfulMatch(sut, 'E');
+            this.VerifySuccessfulMatch(sut, 'H');
+            this.VerifySuccessfulMatch(sut, 'L');
+            this.VerifySuccessfulMatch(sut, 'N');
+            this.VerifySuccessfulMatch(sut, 'P');
+            this.VerifyUnsuccessfulMatch(sut, 'M');
+            this.VerifyUnsuccessfulMatch(sut, 'B');
+            this.VerifyUnsuccessfulMatch(sut, 'Z');
+            this.VerifyUnsuccessfulMatch(sut, 'a');
+            this.VerifyUnsuccessfulMatch(sut, 'e');
+        }
+
+        private void VerifySuccessfulMatch(ChildNodeMap sut, char character)
+        {
+            sut.TryGetValue(character, out var nextNode).Should().BeTrue();
+            nextNode!.IntraNodeText.ToString().Should().BeEquivalentTo(character.ToString());
+        }
+
+        private void VerifyUnsuccessfulMatch(ChildNodeMap sut, char character)
+        {
+            sut.TryGetValue(character, out var nextNode).Should().BeFalse();
+        }
+
+        private static ChildNodeMapEntry CreateTestIndexNodeMap(char character)
+        {
+            return new(
+                character,
+                new IndexNode(character.ToString().AsMemory(), new ChildNodeMap(), new DocumentTokenMatchMap()));
+        }
+    }
+}

--- a/test/Lifti.Tests/FullTextIndexTests.cs
+++ b/test/Lifti.Tests/FullTextIndexTests.cs
@@ -622,46 +622,16 @@ namespace Lifti.Tests
             public string Text3 { get; }
         }
 
-        public class TestObject2
+        public record TestObject2(string Id, params string[] Text);
+
+        public record TestObject3(string Id, string Text, params string[] MultiText);
+
+        public class DynamicObject(string id, string details, Dictionary<string, string> dynamicFields, params FullTextIndexTests.ExtraField[] extraFields)
         {
-            public TestObject2(string id, params string[] text)
-            {
-                this.Id = id;
-                this.Text = text;
-            }
-
-            public string Id { get; }
-            public string[] Text { get; }
-        }
-
-        public class TestObject3
-        {
-            public TestObject3(string id, string text, params string[] multiText)
-            {
-                this.Id = id;
-                this.Text = text;
-                this.MultiText = multiText;
-            }
-
-            public string Id { get; }
-            public string Text { get; }
-            public string[] MultiText { get; }
-        }
-
-        public class DynamicObject
-        {
-            public DynamicObject(string id, string details, Dictionary<string, string> dynamicFields, params ExtraField[] extraFields)
-            {
-                this.Id = id;
-                this.Details = details;
-                this.DynamicFields = dynamicFields;
-                this.ExtraFields = extraFields.Length == 0 ? null : extraFields;
-            }
-
-            public string Id { get; }
-            public string Details { get; }
-            public Dictionary<string, string> DynamicFields { get; }
-            public ExtraField[]? ExtraFields { get; }
+            public string Id { get; } = id;
+            public string Details { get; } = details;
+            public Dictionary<string, string> DynamicFields { get; } = dynamicFields;
+            public ExtraField[]? ExtraFields { get; } = extraFields.Length == 0 ? null : extraFields;
         }
 
         public record ExtraField(string Name, string Value);

--- a/test/Lifti.Tests/FullTextIndexTests.cs
+++ b/test/Lifti.Tests/FullTextIndexTests.cs
@@ -471,7 +471,7 @@ namespace Lifti.Tests
 
             await this.index.CommitBatchChangeAsync();
 
-            this.index.Root.Should().BeEquivalentTo(previousRoot);
+            this.index.Root.ToString().Should().BeEquivalentTo(previousRoot.ToString());
         }
 
         [Fact]
@@ -551,8 +551,8 @@ namespace Lifti.Tests
         }
 
         private static async Task<FullTextIndex<string>> CreateDynamicObjectTestIndexAsync(
-            bool usePrefixes = false, 
-            double dynamicField1ScoreBoost = 1D, 
+            bool usePrefixes = false,
+            double dynamicField1ScoreBoost = 1D,
             double dynamicField2ScoreBoost = 1D)
         {
             var index = new FullTextIndexBuilder<string>()

--- a/test/Lifti.Tests/GlobalSuppressions.cs
+++ b/test/Lifti.Tests/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "CA1861:Avoid constant arrays as arguments", Justification = "OK in these unit tests")]

--- a/test/Lifti.Tests/IndexInsertionMutationTests.cs
+++ b/test/Lifti.Tests/IndexInsertionMutationTests.cs
@@ -1,4 +1,5 @@
 ﻿using Lifti.Tokenization;
+using System;
 using Xunit;
 
 namespace Lifti.Tests
@@ -24,7 +25,7 @@ namespace Lifti.Tests
             this.Sut.Add(Item2, FieldId1, new Token(word, this.Locations2.Locations));
             var result = this.Sut.Apply();
 
-            VerifyResult(result, word, new[] { (Item1, this.Locations1), (Item2, this.Locations2) });
+            VerifyResult(result, word, [(Item1, this.Locations1), (Item2, this.Locations2)]);
         }
 
         [Fact]
@@ -36,11 +37,11 @@ namespace Lifti.Tests
             this.Sut.Add(Item4, FieldId1, new Token("a", this.Locations4.Locations));
             var result = this.Sut.Apply();
 
-            VerifyResult(result, null, expectedChildNodes: new[] { 'a', 'b' });
-            VerifyResult(result, new[] { 'a' }, null, new[] { (Item4, this.Locations4) }, new[] { 'p', 'b' });
-            VerifyResult(result, new[] { 'b' }, "anana", new[] { (Item3, this.Locations3) });
-            VerifyResult(result, new[] { 'a', 'b' }, "le", new[] { (Item2, this.Locations2) });
-            VerifyResult(result, new[] { 'a', 'p' }, "ple", new[] { (Item1, this.Locations1) });
+            VerifyResult(result, null, expectedChildNodes: ['a', 'b']);
+            VerifyResult(result, ['a'], null, new[] { (Item4, this.Locations4) }, ['b', 'p']);
+            VerifyResult(result, ['b'], "anana", new[] { (Item3, this.Locations3) });
+            VerifyResult(result, ['a', 'b'], "le", new[] { (Item2, this.Locations2) });
+            VerifyResult(result, ['a', 'p'], "ple", new[] { (Item1, this.Locations1) });
         }
 
         [Fact]
@@ -51,10 +52,10 @@ namespace Lifti.Tests
             this.Sut.Add(Item3, FieldId1, new Token("freddy", this.Locations3.Locations));
             var result = this.Sut.Apply();
 
-            VerifyResult(result, "fre", expectedChildNodes: new[] { 'e', 'd' });
-            VerifyResult(result, new[] { 'e' }, "dom", new[] { (Item1, this.Locations1) });
-            VerifyResult(result, new[] { 'd' }, null, new[] { (Item2, this.Locations2) }, new[] { 'd' });
-            VerifyResult(result, new[] { 'd', 'd' }, "y", new[] { (Item3, this.Locations3) });
+            VerifyResult(result, "fre", expectedChildNodes: ['d', 'e']);
+            VerifyResult(result, ['e'], "dom", new[] { (Item1, this.Locations1) });
+            VerifyResult(result, ['d'], null, new[] { (Item2, this.Locations2) }, ['d']);
+            VerifyResult(result, ['d', 'd'], "y", new[] { (Item3, this.Locations3) });
         }
 
         [Fact]
@@ -65,9 +66,9 @@ namespace Lifti.Tests
             this.Sut.Add(Item3, FieldId1, new Token("tester", this.Locations3.Locations));
             var result = this.Sut.Apply();
 
-            VerifyResult(result, "test", new[] { (Item1, this.Locations1) }, new[] { 'i', 'e' });
-            VerifyResult(result, new[] { 'i' }, "ng", new[] { (Item2, this.Locations2) });
-            VerifyResult(result, new[] { 'e' }, "r", new[] { (Item3, this.Locations3) });
+            VerifyResult(result, "test", new[] { (Item1, this.Locations1) }, ['e', 'i']);
+            VerifyResult(result, ['i'], "ng", new[] { (Item2, this.Locations2) });
+            VerifyResult(result, ['e'], "r", new[] { (Item3, this.Locations3) });
         }
 
         [Fact]
@@ -78,10 +79,10 @@ namespace Lifti.Tests
             this.Sut.Add(Item3, FieldId1, new Token("brokerage", this.Locations3.Locations));
             var result = this.Sut.Apply();
 
-            VerifyResult(result, "broke", expectedChildNodes: new[] { 'r', 'n' });
-            VerifyResult(result, new[] { 'r' }, "", new[] { (Item1, this.Locations1) }, new[] { 'a' });
-            VerifyResult(result, new[] { 'n' }, "", new[] { (Item2, this.Locations2) });
-            VerifyResult(result, new[] { 'r', 'a' }, "ge", new[] { (Item3, this.Locations3) });
+            VerifyResult(result, "broke", expectedChildNodes: ['n', 'r']);
+            VerifyResult(result, ['r'], "", new[] { (Item1, this.Locations1) }, ['a']);
+            VerifyResult(result, ['n'], "", new[] { (Item2, this.Locations2) });
+            VerifyResult(result, ['r', 'a'], "ge", new[] { (Item3, this.Locations3) });
         }
 
         [Theory]
@@ -100,9 +101,14 @@ namespace Lifti.Tests
             this.Sut.Add(Item2, FieldId1, new Token(indexText, this.Locations2.Locations));
             var result = this.Sut.Apply();
 
-            VerifyResult(result, remainingIntraText, expectedChildNodes: new[] { originalSplitChar, newSplitChar });
-            VerifyResult(result, new[] { originalSplitChar }, splitIntraText, new[] { (Item1, this.Locations1) });
-            VerifyResult(result, new[] { newSplitChar }, newIntraText, new[] { (Item2, this.Locations2) });
+            var expectedChildNodes = new[] { originalSplitChar, newSplitChar };
+
+            // The order of child nodes *must* be ascending, so we'll order the array
+            Array.Sort(expectedChildNodes);
+
+            VerifyResult(result, remainingIntraText, expectedChildNodes: expectedChildNodes);
+            VerifyResult(result, [originalSplitChar], splitIntraText, new[] { (Item1, this.Locations1) });
+            VerifyResult(result, [newSplitChar], newIntraText, new[] { (Item2, this.Locations2) });
         }
 
         [Fact]
@@ -112,8 +118,8 @@ namespace Lifti.Tests
             this.Sut.Add(Item2, FieldId1, new Token("NOITA", this.Locations2.Locations));
             var result = this.Sut.Apply();
 
-            VerifyResult(result, "NOITA", new[] { (Item2, this.Locations2) }, expectedChildNodes: new[] { 'Z' });
-            VerifyResult(result, new[] { 'Z' }, "I", new[] { (Item1, this.Locations1) });
+            VerifyResult(result, "NOITA", new[] { (Item2, this.Locations2) }, expectedChildNodes: ['Z']);
+            VerifyResult(result, ['Z'], "I", new[] { (Item1, this.Locations1) });
         }
 
         [Fact]
@@ -124,10 +130,10 @@ namespace Lifti.Tests
             this.Sut.Add(Item3, FieldId1, new Token("w3", this.Locations3.Locations));
             var result = this.Sut.Apply();
 
-            VerifyResult(result, "w", expectedChildNodes: new[] { 'w', '3' });
-            VerifyResult(result, new[] { 'w' }, "w", new[] { (Item1, this.Locations1) });
-            VerifyResult(result, new[] { '3' }, null, new[] { (Item3, this.Locations3) }, new[] { 'c' });
-            VerifyResult(result, new[] { '3', 'c' }, null, new[] { (Item2, this.Locations2) });
-        }        
+            VerifyResult(result, "w", expectedChildNodes: ['3', 'w']);
+            VerifyResult(result, ['w'], "w", new[] { (Item1, this.Locations1) });
+            VerifyResult(result, ['3'], null, new[] { (Item3, this.Locations3) }, ['c']);
+            VerifyResult(result, ['3', 'c'], null, new[] { (Item2, this.Locations2) });
+        }
     }
 }

--- a/test/Lifti.Tests/IndexRemovalMutationTests.cs
+++ b/test/Lifti.Tests/IndexRemovalMutationTests.cs
@@ -14,8 +14,8 @@ namespace Lifti.Tests
 
             var result = this.Sut.Apply();
 
-            VerifyResult(result, "www", expectedChildNodes: new[] { 'w' });
-            VerifyResult(result, new[] { 'w' }, "w");
+            VerifyResult(result, "www", expectedChildNodes: ['w']);
+            VerifyResult(result, ['w'], "w");
         }
 
         [Fact]
@@ -30,8 +30,8 @@ namespace Lifti.Tests
 
             var result = this.Sut.Apply();
 
-            VerifyResult(result, "www", expectedChildNodes: new[] { 'w' });
-            VerifyResult(result, new[] { 'w' }, "w");
+            VerifyResult(result, "www", expectedChildNodes: ['w']);
+            VerifyResult(result, ['w'], "w");
         }
 
         [Fact]
@@ -40,14 +40,20 @@ namespace Lifti.Tests
             this.Sut.Add(Item1, FieldId1, new Token("www", this.Locations1.Locations));
             this.Sut.Add(Item2, FieldId1, new Token("wwwww", this.Locations2.Locations));
 
-            this.ApplyMutationsToNewSut();
+            var result = this.ApplyMutationsToNewSut();
+
+            VerifyResult(result, "www", expectedChildNodes: ['w'], expectedMatches: new[] { (Item1, this.Locations1) });
+            VerifyResult(result, ['w'], "w", new[] { (Item2, this.Locations2) });
 
             this.Sut.Remove(Item1);
 
-            var result = this.Sut.Apply();
+            result = this.Sut.Apply();
 
-            VerifyResult(result, "www", expectedChildNodes: new[] { 'w' });
-            VerifyResult(result, new[] { 'w' }, "w", new[] { (Item2, this.Locations2) });
+            // Item1 should be gone
+            VerifyResult(result, "www", expectedChildNodes: ['w']);
+
+            // But because we only removed Item1, Item2 should still be present
+            VerifyResult(result, ['w'], "w", new[] { (Item2, this.Locations2) });
         }
     }
 }

--- a/test/Lifti.Tests/ItemStoreTests.cs
+++ b/test/Lifti.Tests/ItemStoreTests.cs
@@ -1,7 +1,6 @@
 ﻿using FluentAssertions;
 using Lifti.Tokenization.Objects;
 using System;
-using System.Collections.Immutable;
 using System.Linq;
 using Xunit;
 
@@ -191,7 +190,7 @@ namespace Lifti.Tests
         private static IndexStatistics IndexStatistics(params (byte fieldId, int wordCount)[] fieldTokenCounts)
         {
             return new IndexStatistics(
-                fieldTokenCounts.ToImmutableDictionary(f => f.fieldId, f => (long)f.wordCount),
+                fieldTokenCounts.ToDictionary(f => f.fieldId, f => (long)f.wordCount),
                 fieldTokenCounts.Sum(c => c.wordCount));
         }
     }

--- a/test/Lifti.Tests/Lifti.Tests.csproj
+++ b/test/Lifti.Tests/Lifti.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0;net7.0;net8.0;netframework4.8.1</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>latest</LangVersion>
 	  <Nullable>enable</Nullable>
   </PropertyGroup>
 	

--- a/test/Lifti.Tests/MutationTestBase.cs
+++ b/test/Lifti.Tests/MutationTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using System;
 using System.Linq;
 
 namespace Lifti.Tests
@@ -21,16 +22,16 @@ namespace Lifti.Tests
         {
             this.indexNodeFactory = new IndexNodeFactory(new IndexOptions { SupportIntraNodeTextAfterIndexDepth = 0 });
             this.RootNode = this.indexNodeFactory.CreateRootNode();
-            this.Sut = new IndexMutation(this.RootNode, this.indexNodeFactory);
+            this.Sut = new IndexMutation<int>(this.RootNode, new ItemStore<int>(Array.Empty<IIndexedObjectConfiguration>()), this.indexNodeFactory);
         }
 
         protected IndexNode RootNode { get; }
-        internal IndexMutation Sut { get; set; }
+        internal IndexMutation<int> Sut { get; set; }
 
         protected IndexNode ApplyMutationsToNewSut()
         {
             var applied = this.Sut.Apply();
-            this.Sut = new IndexMutation(applied, this.indexNodeFactory);
+            this.Sut = new IndexMutation<int>(applied, new ItemStore<int>(Array.Empty<IIndexedObjectConfiguration>()), this.indexNodeFactory);
             return applied;
         }
 

--- a/test/Lifti.Tests/MutationTestBase.cs
+++ b/test/Lifti.Tests/MutationTestBase.cs
@@ -46,7 +46,7 @@ namespace Lifti.Tests
             node.HasChildNodes.Should().Be(expectedChildNodes.Length > 0);
             node.HasMatches.Should().Be(expectedMatches.Length > 0);
             node.IntraNodeText.ToArray().Should().BeEquivalentTo(intraNodeText?.ToCharArray() ?? []);
-            node.ChildNodes.Characters.ToArray().Should().BeEquivalentTo(expectedChildNodes, o => o.WithStrictOrdering());
+            node.ChildNodes.CharacterMap.ToArray().Select(x => x.ChildChar).Should().BeEquivalentTo(expectedChildNodes, o => o.WithStrictOrdering());
             node.Matches.Enumerate().SelectMany(x => x.indexedTokens.Select(token => (x.documentId, token))).ToList().Should().BeEquivalentTo(expectedMatches);
         }
 

--- a/test/Lifti.Tests/MutationTestBase.cs
+++ b/test/Lifti.Tests/MutationTestBase.cs
@@ -1,6 +1,4 @@
 ﻿using FluentAssertions;
-using System;
-using System.Collections.Immutable;
 using System.Linq;
 
 namespace Lifti.Tests
@@ -29,9 +27,11 @@ namespace Lifti.Tests
         protected IndexNode RootNode { get; }
         internal IndexMutation Sut { get; set; }
 
-        protected void ApplyMutationsToNewSut()
+        protected IndexNode ApplyMutationsToNewSut()
         {
-            this.Sut = new IndexMutation(this.Sut.Apply(), this.indexNodeFactory);
+            var applied = this.Sut.Apply();
+            this.Sut = new IndexMutation(applied, this.indexNodeFactory);
+            return applied;
         }
 
         protected static void VerifyResult(
@@ -40,14 +40,14 @@ namespace Lifti.Tests
             (int, IndexedToken)[]? expectedMatches = null,
             char[]? expectedChildNodes = null)
         {
-            expectedChildNodes ??= Array.Empty<char>();
-            expectedMatches ??= Array.Empty<(int, IndexedToken)>();
+            expectedChildNodes ??= [];
+            expectedMatches ??= [];
 
             node.HasChildNodes.Should().Be(expectedChildNodes.Length > 0);
             node.HasMatches.Should().Be(expectedMatches.Length > 0);
-            node.IntraNodeText.ToArray().Should().BeEquivalentTo(intraNodeText?.ToCharArray() ?? Array.Empty<char>());
-            node.ChildNodes.Keys.Should().BeEquivalentTo(expectedChildNodes, o => o.WithoutStrictOrdering());
-            node.Matches.Should().BeEquivalentTo(expectedMatches.ToImmutableDictionary(x => x.Item1, x => new[] { x.Item2 }));
+            node.IntraNodeText.ToArray().Should().BeEquivalentTo(intraNodeText?.ToCharArray() ?? []);
+            node.ChildNodes.Characters.ToArray().Should().BeEquivalentTo(expectedChildNodes, o => o.WithStrictOrdering());
+            node.Matches.Enumerate().SelectMany(x => x.indexedTokens.Select(token => (x.documentId, token))).ToList().Should().BeEquivalentTo(expectedMatches);
         }
 
         protected static void VerifyResult(
@@ -59,7 +59,7 @@ namespace Lifti.Tests
         {
             foreach (var navigationChar in navigationChars)
             {
-                node = node.ChildNodes[navigationChar];
+                node.ChildNodes.TryGetValue(navigationChar, out node!).Should().BeTrue();
             }
 
             VerifyResult(node, intraNodeText, expectedMatches, expectedChildNodes);

--- a/test/Lifti.Tests/Querying/OkapiBm25ScorerTests.cs
+++ b/test/Lifti.Tests/Querying/OkapiBm25ScorerTests.cs
@@ -2,7 +2,7 @@
 using Lifti.Querying;
 using Lifti.Tests.Fakes;
 using System;
-using System.Collections.Immutable;
+using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
@@ -16,7 +16,7 @@ namespace Lifti.Tests.Querying
         private readonly QueryTokenMatch[] tokenMatches;
         private static readonly FakeItemStore<int> looseTextItemStore = new(
                 10,
-                new IndexStatistics(ImmutableDictionary<byte, long>.Empty.Add(1, 100), 100), // 100 total tokens in 1 field
+                new IndexStatistics(new Dictionary<byte, long>() { { 1, 100 } }, 100), // 100 total tokens in 1 field
                 Enumerable.Range(0, 10)
                     .Select(id => (id, ItemMetadata<int>.ForLooseText(id, id, new DocumentStatistics(1, id * 3))))
                     .ToArray(), // Each item will have (id * 3) tokens in it
@@ -24,7 +24,7 @@ namespace Lifti.Tests.Querying
 
         private static readonly FakeItemStore<int> objectTextItemStore = new(
                 10,
-                new IndexStatistics(ImmutableDictionary<byte, long>.Empty.Add(1, 100), 100), // 100 total tokens in 1 field
+                new IndexStatistics(new Dictionary<byte, long>() { { 1, 100 } }, 100), // 100 total tokens in 1 field
                 Enumerable.Range(0, 10)
                     .Select(id => (id, ItemMetadata<int>.ForObject(
                         (byte)((id % 3) + 1), // Each item will be assigned to object type 1, 2, or 3 

--- a/test/Lifti.Tests/Serialization/BinarySerializerTests.cs
+++ b/test/Lifti.Tests/Serialization/BinarySerializerTests.cs
@@ -301,7 +301,7 @@ namespace Lifti.Tests.Serialization
             using (var stream = File.Open(fileName, FileMode.CreateNew))
             {
                 var stopwatch = Stopwatch.StartNew();
-                var index = await this.CreateWikipediaIndexAsync();
+                var index = await CreateWikipediaIndexAsync();
                 await serializer.SerializeAsync(index, stream, false);
 
                 this.output.WriteLine($"Serialized in {stopwatch.ElapsedMilliseconds}ms");
@@ -492,7 +492,7 @@ namespace Lifti.Tests.Serialization
             return index;
         }
 
-        private async Task<FullTextIndex<string>> CreateWikipediaIndexAsync()
+        private static async Task<FullTextIndex<string>> CreateWikipediaIndexAsync()
         {
             var index = new FullTextIndexBuilder<string>()
                 .WithTextExtractor<XmlTextExtractor>()

--- a/test/PerformanceProfiling/ChildNodeMapBenchmarks.cs
+++ b/test/PerformanceProfiling/ChildNodeMapBenchmarks.cs
@@ -1,0 +1,113 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Lifti;
+using System;
+
+namespace PerformanceProfiling
+{
+    [LongRunJob(RuntimeMoniker.Net481)]
+    [LongRunJob(RuntimeMoniker.Net70)]
+    [LongRunJob(RuntimeMoniker.Net80)]
+    [LongRunJob(RuntimeMoniker.Net60)]
+    public class ChildNodeMapBenchmarks : IndexBenchmarkBase
+    {
+        private const int OperationCount = 1000000;
+        private ChildNodeMap childNodeMapSingleEntry;
+        private ChildNodeMap childNodeMapTwoEntries;
+        private ChildNodeMap childNodeMapMultipleEntries;
+
+        [IterationSetup]
+        public void SetUp()
+        {
+            var testIndexNode = new IndexNode("test".AsMemory(), new ChildNodeMap(), new DocumentTokenMatchMap());
+            this.childNodeMapSingleEntry = new(
+                [
+                    new ChildNodeMapEntry('A', testIndexNode)
+                ]);
+
+            this.childNodeMapTwoEntries = new(
+                [
+                    new ChildNodeMapEntry('A', testIndexNode),
+                    new ChildNodeMapEntry('E', testIndexNode),
+                ]);
+
+            this.childNodeMapMultipleEntries = new(
+                [
+                    new ChildNodeMapEntry('F', testIndexNode),
+                    new ChildNodeMapEntry('T', testIndexNode),
+                    new ChildNodeMapEntry('V', testIndexNode),
+                    new ChildNodeMapEntry('W', testIndexNode),
+                    new ChildNodeMapEntry('X', testIndexNode),
+                ]);
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationCount)]
+        public object SingleEntry_NotMatched()
+        {
+            var success = this.childNodeMapSingleEntry.TryGetValue('Z', out var nextNode);
+
+            return nextNode;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationCount)]
+        public object SingleEntry_Matched()
+        {
+            var success = this.childNodeMapSingleEntry.TryGetValue('A', out var nextNode);
+
+            return nextNode;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationCount)]
+        public object TwoEntries_NotMatched()
+        {
+            var success = this.childNodeMapTwoEntries.TryGetValue('D', out var nextNode);
+
+            return nextNode;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationCount)]
+        public object TwoEntries_Matched()
+        {
+            var success = this.childNodeMapTwoEntries.TryGetValue('A', out var nextNode)
+                || this.childNodeMapTwoEntries.TryGetValue('E', out nextNode);
+
+            return nextNode;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationCount)]
+        public object MultipleEntries_NotMatched_BeforeStartCharacter()
+        {
+            var success = this.childNodeMapMultipleEntries.TryGetValue('A', out var nextNode);
+
+            return nextNode;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationCount)]
+        public object MultipleEntries_NotMatched_AfterLastCharacter()
+        {
+            var success = this.childNodeMapMultipleEntries.TryGetValue('Z', out var nextNode);
+
+            return nextNode;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationCount)]
+        public object MultipleEntries_NotMatched_InCharacterSet()
+        {
+            var success = this.childNodeMapMultipleEntries.TryGetValue('U', out var nextNode);
+
+            return nextNode;
+        }
+
+        [Benchmark(OperationsPerInvoke = OperationCount)]
+        public object MultipleEntries_Matched()
+        {
+            var success = this.childNodeMapMultipleEntries.TryGetValue('F', out var nextNode)
+                || this.childNodeMapMultipleEntries.TryGetValue('T', out nextNode)
+                || this.childNodeMapMultipleEntries.TryGetValue('V', out nextNode)
+                || this.childNodeMapMultipleEntries.TryGetValue('W', out nextNode)
+                || this.childNodeMapMultipleEntries.TryGetValue('X', out nextNode);
+
+            return nextNode;
+        }
+    }
+}

--- a/test/PerformanceProfiling/IndexSearchingBenchmarks.cs
+++ b/test/PerformanceProfiling/IndexSearchingBenchmarks.cs
@@ -5,21 +5,9 @@ using System.Threading.Tasks;
 
 namespace PerformanceProfiling
 {
-    //public class AntiVirusFriendlyConfig : ManualConfig
-    //{
-    //    public AntiVirusFriendlyConfig()
-    //    {
-    //        this.
-
-    //        AddJob(Job.ShortRun
-    //        .With
-    //            .WithToolchain(InProcessNoEmitToolchain.Instance));
-    //    }
-    //}
-
     [ShortRunJob(RuntimeMoniker.Net481)]
     [ShortRunJob(RuntimeMoniker.Net70)]
-    [MediumRunJob(RuntimeMoniker.Net80)]
+    [ShortRunJob(RuntimeMoniker.Net80)]
     [ShortRunJob(RuntimeMoniker.Net60)]
     [RankColumn, MemoryDiagnoser]
     public class IndexSearchingBenchmarks : IndexBenchmarkBase

--- a/test/PerformanceProfiling/PerformanceProfiling.csproj
+++ b/test/PerformanceProfiling/PerformanceProfiling.csproj
@@ -1,25 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0;netframework4.8.1</TargetFrameworks>
-	  <LangVersion>9.0</LangVersion>
-  </PropertyGroup>
+	<PropertyGroup>
+		<OutputType>Exe</OutputType>
+		<TargetFrameworks>net6.0;net7.0;net8.0;netframework4.8.1</TargetFrameworks>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Remove="WikipediaPages.dat" />
-  </ItemGroup>
+	<ItemGroup>
+		<None Remove="WikipediaPages.dat" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <EmbeddedResource Include="WikipediaPages.dat" />
-  </ItemGroup>
+	<ItemGroup>
+		<EmbeddedResource Include="WikipediaPages.dat" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
-    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+		<PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Lifti.Core\Lifti.Core.csproj" />
-  </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Lifti.Core\Lifti.Core.csproj" />
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
This causes a couple of breaking changes, but removes obvious 3rd party dependencies in the public API #78 

Breaking changes:

**`ChildNodeMap` and `DocumentTokenMatchMap`**:

`IIndexNodeFactory.CreateNode` - instead of taking `ImmutableDictionary`s as the `childNodes` and `matches` parameters, two new structs are provided `ChildNodeMap` and `DocumentTokenMatchMap`:

```csharp
IndexNode CreateNode(
    ReadOnlyMemory<char> intraNodeText,
    ChildNodeMap childNodes,
    DocumentTokenMatchMap matches);
```

These types also replace the immutable dictionaries exposed as properties on `IndexNode`:

```csharp
public ChildNodeMap ChildNodes { get; }
public DocumentTokenMatchMap Matches { get; }
```

`ChildNodeMap` exposes two key methods: `TryGetValue` which operates the same as it does on a dictionary, and `CharacterMap`, a property that returns the set of `ChildNodeMapEntries`.

**`IndexStatistics`**

`IndexStatistics.TokenCountByField` returns `IReadOnlyDictionary<byte, long>` instead of `ImmutableDictionary<byte,long>`


