### PR TITLE
Speed up field collection prior to scoring

### DIFF
--- a/src/Lifti.Core/Querying/IIndexNavigator.cs
+++ b/src/Lifti.Core/Querying/IIndexNavigator.cs
@@ -21,6 +21,24 @@ namespace Lifti.Querying
         IEnumerable<string> EnumerateIndexedTokens();
 
         /// <summary>
+        /// Gets all the matches that are indexed under from where the navigator is located and adds them to the
+        /// given <see cref="MatchCollector"/>.
+        /// </summary>
+        void AddExactAndChildMatches(MatchCollector matchCollector);
+
+        /// <summary>
+        /// Gets all the matches that are indexed exactly at the point of the navigators current location and adds them to the
+        /// given <see cref="MatchCollector"/>.
+        /// </summary>
+        void AddExactMatches(MatchCollector matchCollector);
+
+        /// <summary>
+        /// Creates an <see cref="IntermediateQueryResult"/> from the matches that are indexed under from where the navigator is located,
+        /// scoring them, and applying the given weighting.
+        /// </summary>
+        IntermediateQueryResult CreateIntermediateQueryResult(MatchCollector matches, double weighting = 1);
+
+        /// <summary>
         /// Gets all the matches that are indexed under from where the navigator is located.
         /// </summary>
         /// <param name="weighting">

--- a/src/Lifti.Core/Querying/MatchCollector.cs
+++ b/src/Lifti.Core/Querying/MatchCollector.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Lifti.Querying
+{
+    /// <summary>
+    /// <see cref="MatchCollector"/> is used to aggregate matches from multiple <see cref="IIndexNavigator.AddExactAndChildMatches(MatchCollector)"/> 
+    /// and <see cref="IIndexNavigator.AddExactMatches(MatchCollector)"/> operations. After matches have been collected,
+    /// the resulting <see cref="IntermediateQueryResult"/> can be created using the <see cref="IIndexNavigator.CreateIntermediateQueryResult(MatchCollector, double)"/> method.
+    /// </summary>
+    public sealed class MatchCollector
+    {
+        internal Dictionary<int, List<IndexedToken>> CollectedMatches { get; } = [];
+
+        /// <summary>
+        /// Adds from the specified <paramref name="matches"/> to the collected matches.
+        /// </summary>
+        internal void Add(IEnumerable<(int documentId, IReadOnlyList<IndexedToken> indexedTokens)> matches)
+        {
+            foreach (var (documentId, indexedTokens) in matches)
+            {
+                if (this.CollectedMatches.TryGetValue(documentId, out var existingMatches))
+                {
+                    existingMatches.AddRange(indexedTokens);
+                }
+                else
+                {
+                    if (matches is List<IndexedToken> indexedTokensList)
+                    {
+                        this.CollectedMatches[documentId] = indexedTokensList;
+                    }
+                    else
+                    {
+                        this.CollectedMatches[documentId] = new(indexedTokens);
+                    }
+                }   
+            }
+        }
+    }
+}

--- a/src/Lifti.Core/Querying/QueryParts/IQueryContext.cs
+++ b/src/Lifti.Core/Querying/QueryParts/IQueryContext.cs
@@ -10,5 +10,11 @@
         /// to the given <see cref="IntermediateQueryResult"/>, returning a new <see cref="IntermediateQueryResult"/> instance.
         /// </summary>
         IntermediateQueryResult ApplyTo(IntermediateQueryResult intermediateQueryResult);
+
+        /// <summary>
+        /// Applies any additional filters present in the current query context, e.g. field filters,
+        /// to the given <see cref="MatchCollector"/>, which is mutated as required.
+        /// </summary>
+        void ApplyTo(MatchCollector matchCollector);
     }
 }

--- a/src/Lifti.Core/Querying/QueryParts/QueryContext.cs
+++ b/src/Lifti.Core/Querying/QueryParts/QueryContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace Lifti.Querying.QueryParts
 {
@@ -11,6 +12,19 @@ namespace Lifti.Querying.QueryParts
         private QueryContext(byte? filterToFieldId)
         {
             this.filterToFieldId = filterToFieldId;
+        }
+
+        public void ApplyTo(MatchCollector matchCollector)
+        {
+            if (this.filterToFieldId == null)
+            {
+                return;
+            }
+
+            foreach (var match in matchCollector.CollectedMatches)
+            {
+                match.Value.RemoveAll(fm => fm.FieldId != this.filterToFieldId);
+            }
         }
 
         /// <inheritdoc />

--- a/test/Lifti.Tests/Fakes/FakeQueryContext.cs
+++ b/test/Lifti.Tests/Fakes/FakeQueryContext.cs
@@ -21,5 +21,9 @@ namespace Lifti.Tests.Fakes
         {
             return this.result;
         }
+
+        public void ApplyTo(MatchCollector matchCollector)
+        {
+        }
     }
 }

--- a/test/Lifti.Tests/Querying/FakeIndexNavigator.cs
+++ b/test/Lifti.Tests/Querying/FakeIndexNavigator.cs
@@ -69,6 +69,21 @@ namespace Lifti.Tests.Querying
             return this.ExpectedExactMatches;
         }
 
+        public void AddExactAndChildMatches(MatchCollector matchCollector)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void AddExactMatches(MatchCollector matchCollector)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IntermediateQueryResult CreateIntermediateQueryResult(MatchCollector matches, double weighting = 1)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool Process(char value)
         {
             this.NavigatedCharacters.Add(value);

--- a/test/Lifti.Tests/Querying/QueryParts/WildcardQueryPartTests.cs
+++ b/test/Lifti.Tests/Querying/QueryParts/WildcardQueryPartTests.cs
@@ -28,7 +28,7 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithSingleTextFragment_ShouldReturnOnlyExactMatches()
         {
-            var part = new WildcardQueryPart(new[] { WildcardQueryFragment.CreateText("ALSO") });
+            var part = new WildcardQueryPart([WildcardQueryFragment.CreateText("ALSO")]);
             var results = this.index.Search(new Query(part)).ToList();
 
             results.Should().HaveCount(1);
@@ -43,7 +43,7 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithSScoreBoost_ShouldApplyBoostToResultingScore()
         {
-            var part = new WildcardQueryPart(new[] { WildcardQueryFragment.CreateText("ALSO") });
+            var part = new WildcardQueryPart([WildcardQueryFragment.CreateText("ALSO")]);
             var unboostedScore = this.index.Search(new Query(part)).ToList()[0].Score;
             part = new WildcardQueryPart(new[] { WildcardQueryFragment.CreateText("ALSO") }, 2D);
             var boostedScore = this.index.Search(new Query(part)).ToList()[0].Score;
@@ -54,12 +54,12 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithSingleCharacterReplacement_ShouldReturnCorrectResults()
         {
-            var part = new WildcardQueryPart(new[]
-            {
+            var part = new WildcardQueryPart(
+            [
                 WildcardQueryFragment.CreateText("TH"),
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.CreateText("S")
-            });
+            ]);
 
             var results = this.index.Search(new Query(part)).ToList();
 
@@ -81,12 +81,12 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithTerminatingSingleCharacterReplacement_ShouldReturnCorrectResults()
         {
-            var part = new WildcardQueryPart(new[]
-            {
+            var part = new WildcardQueryPart(
+            [
                 WildcardQueryFragment.CreateText("TH"),
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.SingleCharacter
-            });
+            ]);
 
             var results = this.index.Search(new Query(part)).ToList();
 
@@ -108,11 +108,11 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithTerminatingMultiCharacterReplacement_ShouldReturnAllMatchesStartingWithText()
         {
-            var part = new WildcardQueryPart(new[]
-            {
+            var part = new WildcardQueryPart(
+            [
                 WildcardQueryFragment.CreateText("A"),
                 WildcardQueryFragment.MultiCharacter
-            });
+            ]);
 
             var results = this.index.Search(new Query(part)).ToList();
 
@@ -138,11 +138,11 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithLeadingMultiCharacterReplacement_ShouldReturnAllMatchesEndingWithText()
         {
-            var part = new WildcardQueryPart(new[]
-            {
+            var part = new WildcardQueryPart(
+            [
                 WildcardQueryFragment.MultiCharacter,
                 WildcardQueryFragment.CreateText("ES")
-            });
+            ]);
 
             var results = this.index.Search(new Query(part)).ToList();
 
@@ -165,11 +165,11 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithSequenceOfSingleCharacterWildcards_ShouldOnlyMatchWordsWithMatchingCharacterCounts()
         {
-            var part = new WildcardQueryPart(new[]
-            {
+            var part = new WildcardQueryPart(
+            [
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.SingleCharacter
-            });
+            ]);
 
             var results = this.index.Search(new Query(part)).ToList();
 
@@ -185,8 +185,8 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithSequenceOfSingleCharacterWildcardsFollowedByMultiCharacterWildcard_ShouldMatchWordsWithAtLeastCharacterCount()
         {
-            var part = new WildcardQueryPart(new[]
-            {
+            var part = new WildcardQueryPart(
+            [
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.SingleCharacter,
@@ -194,7 +194,7 @@ namespace Lifti.Tests.Querying.QueryParts
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.MultiCharacter
-            });
+            ]);
 
             var results = this.index.Search(new Query(part)).ToList();
 
@@ -218,13 +218,13 @@ namespace Lifti.Tests.Querying.QueryParts
         [Fact]
         public void Evaluating_WithConsecutiveSingleCharacterReplacement_ShouldReturnCorrectResults()
         {
-            var part = new WildcardQueryPart(new[]
-            {
+            var part = new WildcardQueryPart(
+            [
                 WildcardQueryFragment.CreateText("T"),
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.SingleCharacter,
                 WildcardQueryFragment.CreateText("S")
-            });
+            ]);
 
             var results = this.index.Search(new Query(part)).ToList();
 

--- a/test/PerformanceProfiling/IndexSearchingBenchmarks.cs
+++ b/test/PerformanceProfiling/IndexSearchingBenchmarks.cs
@@ -5,10 +5,10 @@ using System.Threading.Tasks;
 
 namespace PerformanceProfiling
 {
-    [ShortRunJob(RuntimeMoniker.Net481)]
-    [ShortRunJob(RuntimeMoniker.Net70)]
+    //[ShortRunJob(RuntimeMoniker.Net481)]
+    //[ShortRunJob(RuntimeMoniker.Net70)]
     [ShortRunJob(RuntimeMoniker.Net80)]
-    [ShortRunJob(RuntimeMoniker.Net60)]
+    //[ShortRunJob(RuntimeMoniker.Net60)]
     [RankColumn, MemoryDiagnoser]
     public class IndexSearchingBenchmarks : IndexBenchmarkBase
     {
@@ -22,19 +22,19 @@ namespace PerformanceProfiling
         }
 
         [Params(
-            "(confiscation & th*) | \"and they\"",
+            //"(confiscation & th*) | \"and they\"",
             "*",
             "th*",
-            "and they also",
+            //"and they also",
             "?and ?they ?also",
             "con??*",
-            "Title=?great",
-            "confiscation",
-            "and > they",
-            "and ~10> they",
-            "\"also has a\"",
-            "and | they",
-            "and ~ they"
+            "Title=?great"
+            //"confiscation",
+            //"and > they",
+            //"and ~10> they",
+            //"\"also has a\"",
+            //"and | they",
+            //"and ~ they"
             )]
         public string SearchCriteria { get; set; }
 

--- a/test/PerformanceProfiling/IndexSearchingBenchmarks.cs
+++ b/test/PerformanceProfiling/IndexSearchingBenchmarks.cs
@@ -5,10 +5,10 @@ using System.Threading.Tasks;
 
 namespace PerformanceProfiling
 {
-    //[ShortRunJob(RuntimeMoniker.Net481)]
-    //[ShortRunJob(RuntimeMoniker.Net70)]
+    [ShortRunJob(RuntimeMoniker.Net481)]
+    [ShortRunJob(RuntimeMoniker.Net70)]
     [ShortRunJob(RuntimeMoniker.Net80)]
-    //[ShortRunJob(RuntimeMoniker.Net60)]
+    [ShortRunJob(RuntimeMoniker.Net60)]
     [RankColumn, MemoryDiagnoser]
     public class IndexSearchingBenchmarks : IndexBenchmarkBase
     {
@@ -22,19 +22,19 @@ namespace PerformanceProfiling
         }
 
         [Params(
-            //"(confiscation & th*) | \"and they\"",
+            "(confiscation & th*) | \"and they\"",
             "*",
             "th*",
-            //"and they also",
+            "and they also",
             "?and ?they ?also",
             "con??*",
-            "Title=?great"
-            //"confiscation",
-            //"and > they",
-            //"and ~10> they",
-            //"\"also has a\"",
-            //"and | they",
-            //"and ~ they"
+            "Title=?great",
+            "confiscation",
+            "and > they",
+            "and ~10> they",
+            "\"also has a\"",
+            "and | they",
+            "and ~ they"
             )]
         public string SearchCriteria { get; set; }
 


### PR DESCRIPTION
This PR allows query parts to collect together a set of matches prior to the final scoring. This reduces the need to allocate memory unioning lots of `IntermediataQueryResult` instances.